### PR TITLE
Add API docs generation using Scribe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: Generate API docs
+        run: php artisan scribe:generate
+      - name: Run tests
+        run: vendor/bin/phpunit --testdox

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ docker-compose up
 The application will be available on `http://localhost:8000` and MySQL will listen on
 port `3306`. A dedicated service runs the queue worker using `php artisan queue:work`.
 
+Generated API documentation can be viewed at `/docs` once the containers are up.
+
 ## Learning Laravel
 
 Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
@@ -69,6 +71,10 @@ In order to ensure that the Laravel community is welcoming to all, please review
 ## Security Vulnerabilities
 
 If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+
+## API documentation
+
+Documentation for this project's API is automatically generated during CI builds and can be accessed in your running environment at `/docs`.
 
 ## License
 

--- a/app/Http/Controllers/Api/V1/JobController.php
+++ b/app/Http/Controllers/Api/V1/JobController.php
@@ -9,11 +9,25 @@ use Illuminate\Http\Request;
 
 class JobController extends Controller
 {
+    /**
+     * List all jobs
+     *
+     * Returns a collection of job posts.
+     *
+     * @group Jobs
+     */
     public function index()
     {
         return JobResource::collection(Job_Posts::all());
     }
 
+    /**
+     * Show a specific job
+     *
+     * @group Jobs
+     *
+     * @urlParam job int required The ID of the job.
+     */
     public function show(Job_Posts $job)
     {
         return new JobResource($job);

--- a/app/Http/Controllers/Api/V1/ProfileController.php
+++ b/app/Http/Controllers/Api/V1/ProfileController.php
@@ -9,11 +9,25 @@ use Illuminate\Http\Request;
 
 class ProfileController extends Controller
 {
+    /**
+     * List all profiles
+     *
+     * Returns a collection of work profiles.
+     *
+     * @group Profiles
+     */
     public function index()
     {
         return ProfileResource::collection(Profile_Posts::all());
     }
 
+    /**
+     * Show a specific profile
+     *
+     * @group Profiles
+     *
+     * @urlParam profile int required The ID of the profile.
+     */
     public function show(Profile_Posts $profile)
     {
         return new ProfileResource($profile);

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
         "nunomaduro/larastan": "^1.0",
-        "phpunit/phpunit": "^9.3.3"
+        "phpunit/phpunit": "^9.3.3",
+        "knuckleswtf/scribe": "^5.2"
     },
     "config": {
         "optimize-autoloader": true,

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -1,0 +1,252 @@
+<?php
+
+use Knuckles\Scribe\Extracting\Strategies;
+use Knuckles\Scribe\Config\Defaults;
+use Knuckles\Scribe\Config\AuthIn;
+use function Knuckles\Scribe\Config\{removeStrategies, configureStrategy};
+
+// Only the most common configs are shown. See the https://scribe.knuckles.wtf/laravel/reference/config for all.
+
+return [
+    // The HTML <title> for the generated documentation.
+    'title' => config('app.name').' API Documentation',
+
+    // A short description of your API. Will be included in the docs webpage, Postman collection and OpenAPI spec.
+    'description' => '',
+
+    // The base URL displayed in the docs.
+    // If you're using `laravel` type, you can set this to a dynamic string, like '{{ config("app.tenant_url") }}' to get a dynamic base URL.
+    'base_url' => config("app.url"),
+
+    // Routes to include in the docs
+    'routes' => [
+        [
+            'match' => [
+                // Match only routes whose paths match this pattern (use * as a wildcard to match any characters). Example: 'users/*'.
+                'prefixes' => ['api/*'],
+
+                // Match only routes whose domains match this pattern (use * as a wildcard to match any characters). Example: 'api.*'.
+                'domains' => ['*'],
+            ],
+
+            // Include these routes even if they did not match the rules above.
+            'include' => [
+                // 'users.index', 'POST /new', '/auth/*'
+            ],
+
+            // Exclude these routes even if they matched the rules above.
+            'exclude' => [
+                // 'GET /health', 'admin.*'
+            ],
+        ],
+    ],
+
+    // The type of documentation output to generate.
+    // - "static" will generate a static HTMl page in the /public/docs folder,
+    // - "laravel" will generate the documentation as a Blade view, so you can add routing and authentication.
+    // - "external_static" and "external_laravel" do the same as above, but pass the OpenAPI spec as a URL to an external UI template
+    'type' => 'laravel',
+
+    // See https://scribe.knuckles.wtf/laravel/reference/config#theme for supported options
+    'theme' => 'default',
+
+    'static' => [
+        // HTML documentation, assets and Postman collection will be generated to this folder.
+        // Source Markdown will still be in resources/docs.
+        'output_path' => 'public/docs',
+    ],
+
+    'laravel' => [
+        // Whether to automatically create a docs route for you to view your generated docs. You can still set up routing manually.
+        'add_routes' => true,
+
+        // URL path to use for the docs endpoint (if `add_routes` is true).
+        // By default, `/docs` opens the HTML page, `/docs.postman` opens the Postman collection, and `/docs.openapi` the OpenAPI spec.
+        'docs_url' => '/docs',
+
+        // Directory within `public` in which to store CSS and JS assets.
+        // By default, assets are stored in `public/vendor/scribe`.
+        // If set, assets will be stored in `public/{{assets_directory}}`
+        'assets_directory' => null,
+
+        // Middleware to attach to the docs endpoint (if `add_routes` is true).
+        'middleware' => [],
+    ],
+
+    'external' => [
+        'html_attributes' => []
+    ],
+
+    'try_it_out' => [
+        // Add a Try It Out button to your endpoints so consumers can test endpoints right from their browser.
+        // Don't forget to enable CORS headers for your endpoints.
+        'enabled' => true,
+
+        // The base URL to use in the API tester. Leave as null to be the same as the displayed URL (`scribe.base_url`).
+        'base_url' => null,
+
+        // [Laravel Sanctum] Fetch a CSRF token before each request, and add it as an X-XSRF-TOKEN header.
+        'use_csrf' => false,
+
+        // The URL to fetch the CSRF token from (if `use_csrf` is true).
+        'csrf_url' => '/sanctum/csrf-cookie',
+    ],
+
+    // How is your API authenticated? This information will be used in the displayed docs, generated examples and response calls.
+    'auth' => [
+        // Set this to true if ANY endpoints in your API use authentication.
+        'enabled' => false,
+
+        // Set this to true if your API should be authenticated by default. If so, you must also set `enabled` (above) to true.
+        // You can then use @unauthenticated or @authenticated on individual endpoints to change their status from the default.
+        'default' => false,
+
+        // Where is the auth value meant to be sent in a request?
+        'in' => AuthIn::BEARER->value,
+
+        // The name of the auth parameter (e.g. token, key, apiKey) or header (e.g. Authorization, Api-Key).
+        'name' => 'key',
+
+        // The value of the parameter to be used by Scribe to authenticate response calls.
+        // This will NOT be included in the generated documentation. If empty, Scribe will use a random value.
+        'use_value' => env('SCRIBE_AUTH_KEY'),
+
+        // Placeholder your users will see for the auth parameter in the example requests.
+        // Set this to null if you want Scribe to use a random value as placeholder instead.
+        'placeholder' => '{YOUR_AUTH_KEY}',
+
+        // Any extra authentication-related info for your users. Markdown and HTML are supported.
+        'extra_info' => 'You can retrieve your token by visiting your dashboard and clicking <b>Generate API token</b>.',
+    ],
+
+    // Text to place in the "Introduction" section, right after the `description`. Markdown and HTML are supported.
+    'intro_text' => <<<INTRO
+        This documentation aims to provide all the information you need to work with our API.
+
+        <aside>As you scroll, you'll see code examples for working with the API in different programming languages in the dark area to the right (or as part of the content on mobile).
+        You can switch the language used with the tabs at the top right (or from the nav menu at the top left on mobile).</aside>
+    INTRO,
+
+    // Example requests for each endpoint will be shown in each of these languages.
+    // Supported options are: bash, javascript, php, python
+    // To add a language of your own, see https://scribe.knuckles.wtf/laravel/advanced/example-requests
+    // Note: does not work for `external` docs types
+    'example_languages' => [
+        'bash',
+        'javascript',
+    ],
+
+    // Generate a Postman collection (v2.1.0) in addition to HTML docs.
+    // For 'static' docs, the collection will be generated to public/docs/collection.json.
+    // For 'laravel' docs, it will be generated to storage/app/scribe/collection.json.
+    // Setting `laravel.add_routes` to true (above) will also add a route for the collection.
+    'postman' => [
+        'enabled' => true,
+
+        'overrides' => [
+            // 'info.version' => '2.0.0',
+        ],
+    ],
+
+    // Generate an OpenAPI spec (v3.0.1) in addition to docs webpage.
+    // For 'static' docs, the collection will be generated to public/docs/openapi.yaml.
+    // For 'laravel' docs, it will be generated to storage/app/scribe/openapi.yaml.
+    // Setting `laravel.add_routes` to true (above) will also add a route for the spec.
+    'openapi' => [
+        'enabled' => true,
+
+        'overrides' => [
+            // 'info.version' => '2.0.0',
+        ],
+
+        // Additional generators to use when generating the OpenAPI spec.
+        // Should extend `Knuckles\Scribe\Writing\OpenApiSpecGenerators\OpenApiGenerator`.
+        'generators' => [],
+    ],
+
+    'groups' => [
+        // Endpoints which don't have a @group will be placed in this default group.
+        'default' => 'Endpoints',
+
+        // By default, Scribe will sort groups alphabetically, and endpoints in the order their routes are defined.
+        // You can override this by listing the groups, subgroups and endpoints here in the order you want them.
+        // See https://scribe.knuckles.wtf/blog/laravel-v4#easier-sorting and https://scribe.knuckles.wtf/laravel/reference/config#order for details
+        // Note: does not work for `external` docs types
+        'order' => [],
+    ],
+
+    // Custom logo path. This will be used as the value of the src attribute for the <img> tag,
+    // so make sure it points to an accessible URL or path. Set to false to not use a logo.
+    // For example, if your logo is in public/img:
+    // - 'logo' => '../img/logo.png' // for `static` type (output folder is public/docs)
+    // - 'logo' => 'img/logo.png' // for `laravel` type
+    'logo' => false,
+
+    // Customize the "Last updated" value displayed in the docs by specifying tokens and formats.
+    // Examples:
+    // - {date:F j Y} => March 28, 2022
+    // - {git:short} => Short hash of the last Git commit
+    // Available tokens are `{date:<format>}` and `{git:<format>}`.
+    // The format you pass to `date` will be passed to PHP's `date()` function.
+    // The format you pass to `git` can be either "short" or "long".
+    // Note: does not work for `external` docs types
+    'last_updated' => 'Last updated: {date:F j, Y}',
+
+    'examples' => [
+        // Set this to any number to generate the same example values for parameters on each run,
+        'faker_seed' => 1234,
+
+        // With API resources and transformers, Scribe tries to generate example models to use in your API responses.
+        // By default, Scribe will try the model's factory, and if that fails, try fetching the first from the database.
+        // You can reorder or remove strategies here.
+        'models_source' => ['factoryCreate', 'factoryMake', 'databaseFirst'],
+    ],
+
+    // The strategies Scribe will use to extract information about your routes at each stage.
+    // Use configureStrategy() to specify settings for a strategy in the list.
+    // Use removeStrategies() to remove an included strategy.
+    'strategies' => [
+        'metadata' => [
+            ...Defaults::METADATA_STRATEGIES,
+        ],
+        'headers' => [
+            ...Defaults::HEADERS_STRATEGIES,
+            Strategies\StaticData::withSettings(data: [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ]),
+        ],
+        'urlParameters' => [
+            ...Defaults::URL_PARAMETERS_STRATEGIES,
+        ],
+        'queryParameters' => [
+            ...Defaults::QUERY_PARAMETERS_STRATEGIES,
+        ],
+        'bodyParameters' => [
+            ...Defaults::BODY_PARAMETERS_STRATEGIES,
+        ],
+        'responses' => configureStrategy(
+            Defaults::RESPONSES_STRATEGIES,
+            Strategies\Responses\ResponseCalls::withSettings(
+                only: ['GET *'],
+                // Recommended: disable debug mode in response calls to avoid error stack traces in responses
+                config: [
+                    'app.debug' => false,
+                ]
+            )
+        ),
+        'responseFields' => [
+            ...Defaults::RESPONSE_FIELDS_STRATEGIES,
+        ]
+    ],
+
+    // For response calls, API resource responses and transformer responses,
+    // Scribe will try to start database transactions, so no changes are persisted to your database.
+    // Tell Scribe which connections should be transacted here. If you only use one db connection, you can leave this as is.
+    'database_connections_to_transact' => [config('database.default')],
+
+    'fractal' => [
+        // If you are using a custom serializer with league/fractal, you can specify it here.
+        'serializer' => null,
+    ],
+];


### PR DESCRIPTION
## Summary
- install knuckleswtf/scribe as dev dependency
- publish Scribe config with output path set to `public/docs`
- document API controllers with annotations
- add docs generation step in CI
- mention `/docs` in README

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_686fdcc99a98832ea21a5dc00aacc4e1