### PR TITLE
Clear OTP after verifying email

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -234,6 +234,9 @@ class UserController extends Controller
         }
         if ($user->markEmailAsVerified()) {
             event(new Verified($user));
+            $user->otp = null;
+            $user->otp_send_at = null;
+            $user->save();
         }
 
         $user_type = $user->type;


### PR DESCRIPTION
## Summary
- reset `otp` and `otp_send_at` once the email is verified

## Testing
- `composer test` *(fails: composer not installed)*
- `vendor/bin/phpunit --version` *(fails: phpunit missing)*

------
https://chatgpt.com/codex/tasks/task_b_68702d780bbc832eaf32ed908a0ef24d