### PR TITLE
Fix OTP resend method call

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -261,7 +261,7 @@ class UserController extends Controller
         $this->userService->updateOTPDetails($user);
         $user = $this->userService->getUser($user->id);
 
-        if ($user->sendEmailVerificationNotification(true)) {
+        if ($user->sendEmailVerificationNotification()) {
             return back()->with('alert-success', 'OTP email sent successfully.');
         } else {
             return back()->with('alert-danger', 'Could not sent OTP email. Please try after some time.');


### PR DESCRIPTION
## Summary
- fix UserController::verifyResendOTP to remove unused parameter

## Testing
- `npm test` *(fails: Missing script)*
- `./vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_b_68702d6f68e4832ebf36d978e8aed17e