### PR TITLE
Add Scribe docs instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 
 Documentation for this project's API is automatically generated during CI builds and can be accessed in your running environment at `/docs`.
 
+To generate the docs locally, run:
+
+```bash
+php artisan scribe:generate
+```
+
+You may also run `composer docs` if you have installed the Composer script.
+
+The OpenAPI specification is available at `/docs.openapi`.
+
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,9 @@
         ],
         "lint:cs": [
             "./vendor/bin/php-cs-fixer fix -vvv --show-progress=dots"
+        ],
+        "docs": [
+            "php artisan scribe:generate"
         ]
     }
 }


### PR DESCRIPTION
## Summary
- document how to generate Scribe docs locally
- add `composer docs` command for convenience

## Testing
- `composer docs` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_b_68715eb6ef2c832ebc699146473f0fc1