### PR TITLE
Add geolocation support

### DIFF
--- a/app/Http/Controllers/Api/V1/ProfileController.php
+++ b/app/Http/Controllers/Api/V1/ProfileController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ProfileResource;
 use App\Models\Profile_Posts;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Http\Request;
 
 class ProfileController extends Controller
@@ -31,5 +32,45 @@ class ProfileController extends Controller
     public function show(Profile_Posts $profile)
     {
         return new ProfileResource($profile);
+    }
+
+    /**
+     * Nearby providers
+     *
+     * Returns profiles within the given radius using latitude and longitude.
+     *
+     * @group Profiles
+     *
+     * @queryParam lat required Latitude Example: 51.5074
+     * @queryParam lng required Longitude Example: -0.1278
+     * @queryParam radius required Distance in kilometers Example: 10
+     */
+    public function nearby(Request $request)
+    {
+        $data = $request->validate([
+            'lat' => 'required|numeric',
+            'lng' => 'required|numeric',
+            'radius' => 'required|numeric',
+        ]);
+
+        $lat = $data['lat'];
+        $lng = $data['lng'];
+        $radius = $data['radius'];
+
+        $profiles = Profile_Posts::select('profile_posts.*')
+            ->join('users', 'users.id', '=', 'profile_posts.provider_id')
+            ->selectRaw('(
+                6371 * acos(
+                    cos(radians(?)) * cos(radians(users.latitude)) * cos(radians(users.longitude) - radians(?)) +
+                    sin(radians(?)) * sin(radians(users.latitude))
+                )
+            ) as distance', [$lat, $lng, $lat])
+            ->whereNotNull('users.latitude')
+            ->whereNotNull('users.longitude')
+            ->having('distance', '<=', $radius)
+            ->orderBy('distance')
+            ->get();
+
+        return ProfileResource::collection($profiles);
     }
 }

--- a/app/Models/Job_Posts.php
+++ b/app/Models/Job_Posts.php
@@ -5,11 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Traits\Geocodable;
 
 class Job_Posts extends Model
 {
     use HasFactory;
     use SoftDeletes;
+    use Geocodable;
 
     protected $table = 'job_posts';
 

--- a/app/Models/Profile_Posts.php
+++ b/app/Models/Profile_Posts.php
@@ -11,6 +11,21 @@ class Profile_Posts extends Model
     use HasFactory;
     use SoftDeletes;
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::saving(function ($model) {
+            if (!$model->latitude || !$model->longitude) {
+                $user = $model->userdetails;
+                if ($user) {
+                    $model->latitude = $user->latitude;
+                    $model->longitude = $user->longitude;
+                }
+            }
+        });
+    }
+
     protected $table = 'profile_posts';
 
     protected $guarded = [];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Traits\Geocodable;
 
 use App\Notifications\UserVerificationEmail;
 use Illuminate\Support\Facades\Mail;
@@ -17,6 +18,7 @@ class User extends Authenticatable implements MustVerifyEmail
     use HasFactory;
     use Notifiable;
     use SoftDeletes;
+    use \App\Traits\Geocodable;
 
     /**
      * The attributes that are mass assignable.
@@ -40,6 +42,8 @@ class User extends Authenticatable implements MustVerifyEmail
         'landmark',
         'profile_picture',
         'address',
+        'latitude',
+        'longitude',
         'native_language',
         'birth_date',
         'company_name',

--- a/app/Traits/Geocodable.php
+++ b/app/Traits/Geocodable.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Http;
+
+trait Geocodable
+{
+    protected static function bootGeocodable()
+    {
+        static::saving(function ($model) {
+            if ($model->isDirty('address')) {
+                $model->fillCoordinates();
+            }
+        });
+    }
+
+    public function fillCoordinates()
+    {
+        if (!empty($this->address)) {
+            try {
+                $response = Http::get('https://nominatim.openstreetmap.org/search', [
+                    'q' => $this->address,
+                    'format' => 'json',
+                    'limit' => 1,
+                ]);
+                if ($response->successful() && isset($response[0]['lat'])) {
+                    $this->latitude = $response[0]['lat'];
+                    $this->longitude = $response[0]['lon'];
+                }
+            } catch (\Exception $e) {
+                // ignore failures
+            }
+        }
+    }
+}

--- a/database/migrations/2025_07_11_190931_add_lat_lng_to_users_table.php
+++ b/database/migrations/2025_07_11_190931_add_lat_lng_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->decimal('latitude', 10, 7)->nullable()->after('address');
+            $table->decimal('longitude', 10, 7)->nullable()->after('latitude');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['latitude', 'longitude']);
+        });
+    }
+};

--- a/database/migrations/2025_07_11_190932_add_lat_lng_to_job_posts_table.php
+++ b/database/migrations/2025_07_11_190932_add_lat_lng_to_job_posts_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('job_posts', function (Blueprint $table) {
+            $table->decimal('latitude', 10, 7)->nullable()->after('address');
+            $table->decimal('longitude', 10, 7)->nullable()->after('latitude');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('job_posts', function (Blueprint $table) {
+            $table->dropColumn(['latitude', 'longitude']);
+        });
+    }
+};

--- a/database/migrations/2025_07_11_190933_add_lat_lng_to_profile_posts_table.php
+++ b/database/migrations/2025_07_11_190933_add_lat_lng_to_profile_posts_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('profile_posts', function (Blueprint $table) {
+            $table->decimal('latitude', 10, 7)->nullable()->after('edu_description');
+            $table->decimal('longitude', 10, 7)->nullable()->after('latitude');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('profile_posts', function (Blueprint $table) {
+            $table->dropColumn(['latitude', 'longitude']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,4 +19,5 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('v1')->group(function () {
     Route::apiResource('jobs', JobController::class)->only(['index', 'show']);
     Route::apiResource('profiles', ProfileController::class)->only(['index', 'show']);
+    Route::get('profiles/nearby', [ProfileController::class, 'nearby']);
 });

--- a/tests/Feature/ApiEndpointsTest.php
+++ b/tests/Feature/ApiEndpointsTest.php
@@ -11,20 +11,34 @@ class ApiEndpointsTest extends TestCase
     {
         parent::setUp();
 
+        Schema::create('users', function ($table) {
+            $table->id();
+            $table->string('address')->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->timestamps();
+        });
+
         Schema::create('job_posts', function ($table) {
             $table->id();
             $table->string('jobtitle')->nullable();
             $table->string('city')->nullable();
             $table->string('country')->nullable();
+            $table->string('address')->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
             $table->softDeletes();
             $table->timestamps();
         });
 
         Schema::create('profile_posts', function ($table) {
             $table->id();
+            $table->unsignedBigInteger('provider_id')->nullable();
             $table->integer('profile_category_id')->nullable();
             $table->decimal('payamount')->nullable();
             $table->string('currency')->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
             $table->softDeletes();
             $table->timestamps();
         });
@@ -34,6 +48,7 @@ class ApiEndpointsTest extends TestCase
     {
         Schema::dropIfExists('job_posts');
         Schema::dropIfExists('profile_posts');
+        Schema::dropIfExists('users');
 
         parent::tearDown();
     }
@@ -48,5 +63,25 @@ class ApiEndpointsTest extends TestCase
     {
         $response = $this->get('/api/v1/profiles');
         $response->assertStatus(200)->assertJson(['data' => []]);
+    }
+
+    public function test_profiles_nearby_endpoint_returns_success()
+    {
+        \DB::table('users')->insert([
+            'id' => 1,
+            'address' => 'London',
+            'latitude' => 51.5,
+            'longitude' => -0.12,
+        ]);
+
+        \DB::table('profile_posts')->insert([
+            'provider_id' => 1,
+            'profile_category_id' => 1,
+            'payamount' => 100,
+            'currency' => 'USD',
+        ]);
+
+        $response = $this->get('/api/v1/profiles/nearby?lat=51.5&lng=-0.12&radius=10');
+        $response->assertStatus(200)->assertJsonStructure(['data']);
     }
 }


### PR DESCRIPTION
## Summary
- add reusable `Geocodable` trait to compute coordinates using Nominatim
- attach trait to `User` and `Job_Posts` models
- fill profile coordinates from associated user
- create migrations for latitude/longitude columns
- add `profiles/nearby` endpoint with Haversine search
- document endpoint with Scribe annotations
- test basic functionality of the new endpoint

## Testing
- `composer install` *(fails: package missing)*
- `composer lint` *(fails: php-cs-fixer missing)*
- `./vendor/bin/phpunit` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68716055fdd0832ebf1f35ad50e9fb5b