### PR TITLE
Add Prometheus/Grafana monitoring setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ docker-compose up
 
 The application will be available on `http://localhost:8000` and MySQL will listen on
 port `3306`. A dedicated service runs the queue worker using `php artisan queue:work`.
+Prometheus and Grafana containers are also available for basic metrics exploration.
+Access them at:
+
+- Prometheus: <http://localhost:9090>
+- Grafana: <http://localhost:3000> (default login is `admin` / `secret`)
+
+Prometheus reads its configuration from `prometheus.yml` in the project root.
 
 Generated API documentation can be viewed at `/docs` once the containers are up.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,28 @@ services:
     ports:
       - "3306:3306"
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: kynderway_prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - app
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: kynderway_grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: secret
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana_data:/var/lib/grafana
+
 volumes:
   dbdata:
+  grafana_data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']
+


### PR DESCRIPTION
## Summary
- extend `docker-compose.yml` with Prometheus and Grafana services
- add a minimal `prometheus.yml` configuration
- document monitoring URLs in README

## Testing
- `composer install --no-dev --no-interaction --no-progress` *(fails: Knuckles\Scribe missing)*
- `php artisan test` *(fails: Class `Knuckles\Scribe\Config\AuthIn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687162733288832eb8b710bc72d9944e