### PR TITLE
Integrate Google Maps service

### DIFF
--- a/app/Http/Controllers/Api/MapsController.php
+++ b/app/Http/Controllers/Api/MapsController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\GoogleMapsService;
+use Illuminate\Http\Request;
+
+class MapsController extends Controller
+{
+    protected $mapsService;
+
+    public function __construct(GoogleMapsService $mapsService)
+    {
+        $this->mapsService = $mapsService;
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/maps/geocode",
+     *     summary="Geocode an address",
+     *     @OA\RequestBody(
+     *         @OA\JsonContent(
+     *             @OA\Property(property="address", type="string")
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Success")
+     * )
+     */
+    public function geocode(Request $request)
+    {
+        $request->validate(['address' => 'required|string']);
+
+        $result = $this->mapsService->geocodeAddress($request->address);
+
+        return response()->json($result);
+    }
+}

--- a/app/Services/GoogleMapsService.php
+++ b/app/Services/GoogleMapsService.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services;
+
+use GoogleMaps\Facade\GoogleMapsFacade as GoogleMaps;
+
+class GoogleMapsService
+{
+    /**
+     * Get coordinates from address
+     */
+    public function geocodeAddress($address)
+    {
+        $response = GoogleMaps::load('geocoding')
+            ->setParam(['address' => $address])
+            ->get();
+
+        $result = json_decode($response);
+
+        if ($result->status === 'OK') {
+            return [
+                'lat' => $result->results[0]->geometry->location->lat,
+                'lng' => $result->results[0]->geometry->location->lng,
+                'formatted_address' => $result->results[0]->formatted_address,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get nearby places
+     */
+    public function getNearbyPlaces($lat, $lng, $radius = 1000, $type = 'restaurant')
+    {
+        $response = GoogleMaps::load('nearbysearch')
+            ->setParam([
+                'location' => "$lat,$lng",
+                'radius' => $radius,
+                'type' => $type,
+            ])
+            ->get();
+
+        return json_decode($response);
+    }
+
+    /**
+     * Calculate distance between two points
+     */
+    public function calculateDistance($origin, $destination)
+    {
+        $response = GoogleMaps::load('distancematrix')
+            ->setParam([
+                'origins' => $origin,
+                'destinations' => $destination,
+                'mode' => 'driving',
+            ])
+            ->get();
+
+        return json_decode($response);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
+        "alexpechkarev/google-maps": "^12.0",
         "doctrine/dbal": "^3.1",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,134 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46131156078f830ccc760836962aad7c",
+    "content-hash": "6f7990bc98641dde0b5fc716afa90772",
     "packages": [
+        {
+            "name": "alexpechkarev/geometry-library",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alexpechkarev/geometry-library.git",
+                "reference": "35839ed841805c8a0bc2fd8e4d5b5f600cb1416a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alexpechkarev/geometry-library/zipball/35839ed841805c8a0bc2fd8e4d5b5f600cb1416a",
+                "reference": "35839ed841805c8a0bc2fd8e4d5b5f600cb1416a",
+                "shasum": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GeometryLibrary\\": "/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander Pechkarev",
+                    "email": "alexpechkarev@gmail.com"
+                }
+            ],
+            "description": "PHP Geometry library provides utility functions for the computation of geometric data on the surface of the Earth.",
+            "homepage": "https://alexpechkarev.github.io/geometry-library/",
+            "keywords": [
+                "computations polygons and polylines",
+                "encoding and decoding polyline paths utilities",
+                "google maps geometry library",
+                "php geometry library",
+                "spherical geometry utilities"
+            ],
+            "support": {
+                "issues": "https://github.com/alexpechkarev/geometry-library/issues",
+                "source": "https://github.com/alexpechkarev/geometry-library/tree/1.0.5"
+            },
+            "time": "2024-04-11T17:17:16+00:00"
+        },
+        {
+            "name": "alexpechkarev/google-maps",
+            "version": "v12.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alexpechkarev/google-maps.git",
+                "reference": "65b30d918e07012af14cbb06bfd554db1c7e5145"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alexpechkarev/google-maps/zipball/65b30d918e07012af14cbb06bfd554db1c7e5145",
+                "reference": "65b30d918e07012af14cbb06bfd554db1c7e5145",
+                "shasum": ""
+            },
+            "require": {
+                "alexpechkarev/geometry-library": "^1.0.2|^1.0",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "illuminate/config": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "jbroadway/urlify": "^1.1|^1.2|dev-voku-portable-ascii-2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.7.*|^9.6.3|^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "GoogleMaps": "GoogleMaps\\Facade\\GoogleMapsFacade"
+                    },
+                    "providers": [
+                        "GoogleMaps\\ServiceProvider\\GoogleMapsServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "10.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GoogleMaps\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander Pechkarev",
+                    "email": "alexpechkarev@gmail.com"
+                }
+            ],
+            "description": "Collection of Google Maps API Web Services for Laravel",
+            "homepage": "https://alexpechkarev.github.io/google-maps/",
+            "keywords": [
+                "Google Maps API",
+                "directions api",
+                "distance matrix api",
+                "elevation api",
+                "geocoding api",
+                "geolocation api",
+                "google maps api for laravel",
+                "google maps web service for laravel",
+                "laravel google maps api",
+                "places api web service",
+                "roads api",
+                "time zone api"
+            ],
+            "support": {
+                "issues": "https://github.com/alexpechkarev/google-maps/issues",
+                "source": "https://github.com/alexpechkarev/google-maps/tree/v12.0.0"
+            },
+            "time": "2025-03-03T10:23:04+00:00"
+        },
         {
             "name": "asm89/stack-cors",
             "version": "v2.1.1",
@@ -1497,6 +1623,77 @@
                 }
             ],
             "time": "2025-03-27T12:30:47+00:00"
+        },
+        {
+            "name": "jbroadway/urlify",
+            "version": "1.2.3-stable",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jbroadway/urlify.git",
+                "reference": "b7c142a247bd5fac2bb62ca2491bd151c4d1dee4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jbroadway/urlify/zipball/b7c142a247bd5fac2bb62ca2491bd151c4d1dee4",
+                "reference": "b7c142a247bd5fac2bb62ca2491bd151c4d1dee4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "voku/portable-ascii": "^1.4",
+                "voku/stop-words": "^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "URLify": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause-Clear"
+            ],
+            "authors": [
+                {
+                    "name": "Johnny Broadway",
+                    "email": "johnny@johnnybroadway.com",
+                    "homepage": "http://www.johnnybroadway.com/"
+                }
+            ],
+            "description": "A fast PHP slug generator and transliteration library that converts non-ascii characters for use in URLs.",
+            "homepage": "https://github.com/jbroadway/urlify",
+            "keywords": [
+                "ascii",
+                "blogging",
+                "blogs",
+                "downcode",
+                "encode",
+                "iconv",
+                "link",
+                "seo",
+                "slug",
+                "slugify",
+                "slugs",
+                "translit",
+                "transliterate",
+                "transliteration",
+                "unicode",
+                "url",
+                "urlify"
+            ],
+            "support": {
+                "issues": "https://github.com/jbroadway/urlify/issues",
+                "source": "https://github.com/jbroadway/urlify/tree/1.2.3-stable"
+            },
+            "time": "2021-12-29T21:23:40+00:00"
         },
         {
             "name": "laravel/framework",
@@ -6375,6 +6572,53 @@
                 }
             ],
             "time": "2022-01-24T18:55:24+00:00"
+        },
+        {
+            "name": "voku/stop-words",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/stop-words.git",
+                "reference": "8e63c0af20f800b1600783764e0ce19e53969f71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/stop-words/zipball/8e63c0af20f800b1600783764e0ce19e53969f71",
+                "reference": "8e63c0af20f800b1600783764e0ce19e53969f71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "http://www.moelleken.org/"
+                }
+            ],
+            "description": "Stop-Words via PHP",
+            "keywords": [
+                "stop words",
+                "stop-words"
+            ],
+            "support": {
+                "issues": "https://github.com/voku/stop-words/issues",
+                "source": "https://github.com/voku/stop-words/tree/master"
+            },
+            "time": "2018-11-23T01:37:27+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/config/googlemaps.php
+++ b/config/googlemaps.php
@@ -1,0 +1,449 @@
+<?php
+
+return [
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Key
+    |--------------------------------------------------------------------------
+    |
+    | Will be used for all web services,
+    | unless overwritten bellow using 'key' parameter
+    |
+    |
+    */
+
+    'key'       => 'ADD_YOUR_SERVICE_KEY_HERE',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Verify SSL Peer
+    |--------------------------------------------------------------------------
+    |
+    | Will be used for all web services to verify
+    | SSL peer (SSL certificate validation)
+    |
+     */
+    'ssl_verify_peer' => FALSE,
+
+    /*
+     |--------------------------------------------------------------------------
+     | CURL's connection timeout
+     |--------------------------------------------------------------------------
+     |
+     | Will be used for all web services to limit
+     | the maximum time tha connection can take in seconds
+     |
+      */
+    'connection_timeout' => 5,
+
+    /*
+     |--------------------------------------------------------------------------
+     | CURL's request timeout
+     |--------------------------------------------------------------------------
+     |
+     | Will be used for all web services to limit
+     | the maximum time a request can take
+     |
+      */
+    'request_timeout' => 30,
+
+    /*
+     |--------------------------------------------------------------------------
+     | CURL's CURLOPT_ENCODING
+     |--------------------------------------------------------------------------
+     |
+     | Will be used for all web services to use compression on requests.
+     |
+     | Sets the contents of the "Accept-Encoding:" header a containing all
+     | supported encoding types.
+     |
+      */
+    'request_use_compression' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Service URL
+    |--------------------------------------------------------------------------
+    | url - web service URL
+    | type - request type POST or GET
+    | key - API key, if different to API key above
+    | endpoint - boolean, indicates whenever output parameter to be used in the request or not
+    | responseDefaultKey - specify default field value to be returned when calling getByKey()
+    | param - accepted request parameters
+    |
+    */
+
+    'service' => [
+
+        'geocoding' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/geocode/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'place_id',
+                        'param'                 => [
+                                                    'address'       => null,
+                                                    'bounds'        => null,
+                                                    'key'           => null,
+                                                    'region'        => null,
+                                                    'language'      => null,
+                                                    'result_type'   => null,
+                                                    'location_type' => null,
+                                                    'latlng'        => null,
+                                                    'place_id'      => null,
+                                                    'components'    => [
+                                                        'route'                 => null,
+                                                        'locality'              => null,
+                                                        'administrative_area'   => null,
+                                                        'postal_code'           => null,
+                                                        'country'               => null,
+                                                        ]
+                                                    ]
+        ],
+
+
+
+        'directions' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/directions/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    =>  'geocoded_waypoints',
+                        'decodePolyline'        =>  true, // true = decode overview_polyline.points to an array of points
+                        'param'                 => [
+                                                    'origin'          => null, // required
+                                                    'destination'     => null, //required
+                                                    'mode'            => null,
+                                                    'waypoints'       => null,
+                                                    'place_id'        => null,
+                                                    'alternatives'    => null,
+                                                    'avoid'           => null,
+                                                    'language'        => null,
+                                                    'units'           => null,
+                                                    'region'          => null,
+                                                    'departure_time'  => null,
+                                                    'arrival_time'    => null,
+                                                    'transit_mode'    => null,
+                                                    'transit_routing_preference' => null,
+                                                    ]
+        ],
+
+
+        'distancematrix' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/distancematrix/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'origin_addresses',
+                        'param'                 => [
+                                                    'origins'        => null,
+                                                    'destinations'   => null,
+                                                    'key'            => null,
+                                                    'mode'           => null,
+                                                    'language'       => null,
+                                                    'avoid'          => null,
+                                                    'units'          => null,
+                                                    'departure_time' => null,
+                                                    'arrival_time'   => null,
+                                                    'transit_mode'   => null,
+                                                    'transit_routing_preference' => null,
+
+                                                    ]
+        ],
+
+
+        'elevation' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/elevation/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'elevation',
+                        'param'                 => [
+                                                    'locations'     => null,
+                                                    'path'          => null,
+                                                    'samples'       => null,
+                                                    'key'           => null,
+                                                    ]
+        ],
+
+
+        'geolocate' => [
+                        'url'                   => 'https://www.googleapis.com/geolocation/v1/geolocate?',
+                        'type'                  => 'POST',
+                        'key'                   =>  null,
+                        'endpoint'              =>  false,
+                        'responseDefaultKey'    => 'location',
+                        'param'                 => [
+                                                    'homeMobileCountryCode' => null,
+                                                    'homeMobileNetworkCode' => null,
+                                                    'radioType'             => null,
+                                                    'carrier'               => null,
+                                                    'considerIp'            => null,
+                                                    'cellTowers' => [
+                                                        'cellId'            => null,
+                                                        'locationAreaCode'  => null,
+                                                        'mobileCountryCode' => null,
+                                                        'mobileNetworkCode' => null,
+                                                        'age'               => null,
+                                                        'signalStrength'    => null,
+                                                        'timingAdvance'     => null,
+                                                        ],
+                                                    'wifiAccessPoints' => [
+                                                        'macAddress'        => null,
+                                                        'signalStrength'    => null,
+                                                        'age'               => null,
+                                                        'channel'           => null,
+                                                        'signalToNoiseRatio'=> null,
+                                                        ],
+                                                    ]
+        ],
+
+
+
+        'snapToRoads' => [
+                        'url'                   => 'https://roads.googleapis.com/v1/snapToRoads?',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  false,
+                        'responseDefaultKey'    => 'snappedPoints',
+                        'param'                 => [
+                                                    'locations'     => null,
+                                                    'path'          => null,
+                                                    'samples'       => null,
+                                                    'key'           => null,
+                                                    ]
+        ],
+
+
+        'speedLimits' => [
+                        'url'                   => 'https://roads.googleapis.com/v1/speedLimits?',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  false,
+                        'responseDefaultKey'    => 'speedLimits',
+                        'param'                 => [
+                                                    'path'          => null,
+                                                    'placeId'       => null,
+                                                    'units'         => null,
+                                                    'key'           => null,
+                                                    ]
+        ],
+
+
+        'timezone' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/timezone/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'dstOffset',
+                        'param'                 => [
+                                                    'location'  => null,
+                                                    'timestamp' => null,
+                                                    'key'       => null,
+                                                    'language'  => null,
+
+                                                    ]
+        ],
+
+
+
+        'nearbysearch' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/nearbysearch/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'results',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'location'      => null,
+                                                    'radius'        => null,
+                                                    'keyword'       => null,
+                                                    'language'      => null,
+                                                    'minprice'      => null,
+                                                    'maxprice'      => null,
+                                                    'name'          => null,
+                                                    'opennow'       => null,
+                                                    'rankby'        => null,
+                                                    'type'          => null, // types depricated, one type may be specified
+                                                    'pagetoken'     => null,
+                                                    'zagatselected' => null,
+                                                    ]
+        ],
+
+
+
+        'textsearch' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/textsearch/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'results',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'query'         => null,
+                                                    'location'      => null,
+                                                    'radius'        => null,
+                                                    'language'      => null,
+                                                    'minprice'      => null,
+                                                    'maxprice'      => null,
+                                                    'opennow'       => null,
+                                                    'type'          => null, // types deprecated, one type may be specified
+                                                    'pagetoken'     => null,
+                                                    'zagatselected' => null,
+                                                   ]
+        ],
+
+
+
+        'radarsearch' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/radarsearch/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'geometry',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'radius'        => null,
+                                                    'location'      => null,
+                                                    'keyword'       => null,
+                                                    'minprice'      => null,
+                                                    'maxprice'      => null,
+                                                    'opennow'       => null,
+                                                    'name'          => null,
+                                                    'type'          => null, // types depricated, one type may be specified
+                                                    'zagatselected' => null,
+                                                    ]
+        ],
+
+
+
+        'placedetails' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/details/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'result',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'placeid'       => null,
+                                                    'extensions'    => null,
+                                                    'language'      => null,
+                                                    ]
+        ],
+
+
+        'placeadd' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/add/',
+                        'type'                  => 'POST',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'place_id',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'accuracy'      => null,
+                                                    'address'       => null,
+                                                    'language'      => null,
+                                                    'location'      => null,
+                                                    'name'          => null,
+                                                    'phone_number'  => null,
+                                                    'types'         => null,// according to docs types still required as string parameter
+                                                    'type'          => null, // types deprecated, one type may be specified
+                                                    'website'       => null,
+                                                    ]
+        ],
+
+
+        'placedelete' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/delete/',
+                        'type'                  => 'POST',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'status',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'place_id'      => null,
+
+                                                    ]
+        ],
+
+
+
+
+        'placephoto' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/photo?',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  false,
+                        'responseDefaultKey'    => 'image',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'photoreference'=> null,
+                                                    'maxheight'     => null,
+                                                    'maxwidth'      => null,
+                                                    ]
+        ],
+
+
+
+
+
+        'placeautocomplete' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/autocomplete/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'predictions',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'input'         => null,
+                                                    'offset'        => null,
+                                                    'location'      => null,
+                                                    'radius'        => null,
+                                                    'language'      => null,
+                                                    'types'         => null, // use string as parameter
+                                                    'type'          => null, // types deprecated, one type may be specified
+                                                    'components'    => null,
+                                                    ]
+        ],
+
+
+
+        'placequeryautocomplete' => [
+                        'url'                   => 'https://maps.googleapis.com/maps/api/place/queryautocomplete/',
+                        'type'                  => 'GET',
+                        'key'                   =>  null,
+                        'endpoint'              =>  true,
+                        'responseDefaultKey'    => 'predictions',
+                        'param'                 => [
+                                                    'key'           => null,
+                                                    'input'         => null,
+                                                    'offset'        => null,
+                                                    'location'      => null,
+                                                    'radius'        => null,
+                                                    'language'      => null,
+                                                    ]
+        ],
+
+    ],
+
+
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | End point
+    |--------------------------------------------------------------------------
+    |
+    |
+    */
+
+    'endpoint' => [
+        'xml'           => 'xml?',
+        'json'          => 'json?',
+    ],
+
+
+
+];

--- a/resources/js/components/MapSearch.vue
+++ b/resources/js/components/MapSearch.vue
@@ -1,0 +1,69 @@
+<template>
+    <div>
+        <input 
+            v-model="searchQuery" 
+            @input="searchPlaces"
+            placeholder="Search location..."
+            class="form-control"
+        />
+        <div id="map" style="height: 400px;"></div>
+    </div>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            searchQuery: '',
+            map: null,
+            marker: null,
+        };
+    },
+
+    mounted() {
+        this.initMap();
+    },
+
+    methods: {
+        initMap() {
+            this.map = new google.maps.Map(document.getElementById('map'), {
+                center: { lat: -34.397, lng: 150.644 },
+                zoom: 8,
+            });
+        },
+
+        async searchPlaces() {
+            if (this.searchQuery.length < 3) return;
+
+            try {
+                const response = await axios.post('/api/maps/geocode', {
+                    address: this.searchQuery,
+                });
+
+                if (response.data) {
+                    this.updateMap(response.data.lat, response.data.lng);
+                }
+            } catch (error) {
+                console.error('Geocoding failed:', error);
+            }
+        },
+
+        updateMap(lat, lng) {
+            const position = { lat, lng };
+
+            this.map.setCenter(position);
+            this.map.setZoom(15);
+
+            if (this.marker) {
+                this.marker.setMap(null);
+            }
+
+            this.marker = new google.maps.Marker({
+                position,
+                map: this.map,
+                title: this.searchQuery,
+            });
+        },
+    },
+};
+</script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\V1\JobController;
 use App\Http\Controllers\Api\V1\ProfileController;
+use App\Http\Controllers\Api\MapsController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -21,3 +22,5 @@ Route::prefix('v1')->group(function () {
     Route::apiResource('profiles', ProfileController::class)->only(['index', 'show']);
     Route::get('profiles/nearby', [ProfileController::class, 'nearby']);
 });
+
+Route::post('maps/geocode', [MapsController::class, 'geocode']);


### PR DESCRIPTION
## Summary
- add Google Maps dependency and publish configuration
- add GoogleMapsService for geocode, nearby search and distance calculation
- create API MapsController with geocode endpoint
- expose maps/geocode route
- add Vue MapSearch component for front end map lookup

## Testing
- `composer lint` *(fails: PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*)*
- `vendor/bin/phpunit` *(fails: 22 errors, 1 failure)*

------
https://chatgpt.com/codex/tasks/task_b_68718e081df8832ea7fdd64b61a92e42