### PR TITLE
Add KYC service and controller

### DIFF
--- a/app/Http/Controllers/KYCController.php
+++ b/app/Http/Controllers/KYCController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\KYCService;
+use Illuminate\Http\Request;
+
+class KYCController extends Controller
+{
+    private $kycService;
+
+    public function __construct(KYCService $kycService)
+    {
+        $this->kycService = $kycService;
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/kyc/verify-document",
+     *     summary="Upload and verify identity document",
+     *     @OA\RequestBody(
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 @OA\Property(property="document", type="file"),
+     *                 @OA\Property(property="document_type", type="string", enum={"passport", "drivers_license", "national_id"})
+     *             )
+     *         )
+     *     )
+     * )
+     */
+    public function verifyDocument(Request $request)
+    {
+        $request->validate([
+            'document' => 'required|file|mimes:jpg,jpeg,png,pdf|max:10240',
+            'document_type' => 'required|in:passport,drivers_license,national_id',
+        ]);
+
+        $path = $request->file('document')->store('kyc-documents', 's3');
+
+        $verification = $this->kycService->verifyIdentityDocument(
+            $request->user(),
+            $path,
+            $request->document_type
+        );
+
+        return response()->json([
+            'status' => $verification->status,
+            'message' => 'Document uploaded and verification in progress',
+        ]);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/kyc/background-check",
+     *     summary="Initiate background check"
+     * )
+     */
+    public function initiateBackgroundCheck(Request $request)
+    {
+        $request->validate([
+            'consent' => 'required|accepted',
+            'ssn' => 'required|string',
+        ]);
+
+        $report = $this->kycService->performBackgroundCheck($request->user());
+
+        return response()->json([
+            'report_id' => $report->id,
+            'status' => 'pending',
+            'estimated_completion' => now()->addDays(3),
+        ]);
+    }
+}

--- a/app/Models/VerificationDocument.php
+++ b/app/Models/VerificationDocument.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class VerificationDocument extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $table = 'verification_documents';
+    protected $guarded = [];
+
+    protected $casts = [
+        'verification_data' => 'array',
+    ];
+}

--- a/app/Services/KYCService.php
+++ b/app/Services/KYCService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Models\VerificationDocument;
+use Aws\Rekognition\RekognitionClient;
+use Illuminate\Support\Facades\Storage;
+
+class KYCService
+{
+    private $rekognition;
+
+    public function __construct()
+    {
+        $this->rekognition = new RekognitionClient([
+            'version' => 'latest',
+            'region' => env('AWS_DEFAULT_REGION'),
+        ]);
+    }
+
+    /**
+     * Verify identity document
+     */
+    public function verifyIdentityDocument($user, $documentPath, $documentType)
+    {
+        // Extract text from document
+        $textDetection = $this->rekognition->detectText([
+            'Image' => [
+                'S3Object' => [
+                    'Bucket' => env('AWS_BUCKET'),
+                    'Name' => $documentPath,
+                ],
+            ],
+        ]);
+
+        // Verify document authenticity
+        $documentAnalysis = $this->analyzeDocument($textDetection, $documentType);
+
+        // Face detection for photo ID
+        if (in_array($documentType, ['passport', 'drivers_license', 'national_id'])) {
+            $faceDetection = $this->detectFaces($documentPath);
+            $documentAnalysis['has_face'] = !empty($faceDetection['FaceDetails']);
+        }
+
+        // Store verification result
+        $verification = VerificationDocument::create([
+            'user_id' => $user->id,
+            'document_type' => $documentType,
+            'document_path' => $documentPath,
+            'verification_data' => $documentAnalysis,
+            'status' => $this->determineVerificationStatus($documentAnalysis),
+        ]);
+
+        return $verification;
+    }
+
+    /**
+     * Perform background check
+     */
+    public function performBackgroundCheck($user)
+    {
+        // Integration with background check services
+        // Examples: Checkr, Sterling, GoodHire
+
+        $backgroundCheckService = new \App\Services\CheckrService();
+
+        $candidate = $backgroundCheckService->createCandidate([
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'dob' => $user->date_of_birth,
+            'ssn' => $user->ssn, // Encrypted
+            'zipcode' => $user->zipcode,
+        ]);
+
+        $report = $backgroundCheckService->createReport($candidate->id, [
+            'package' => 'childcare_pro', // Criminal, sex offender registry, etc.
+        ]);
+
+        return $report;
+    }
+
+    /**
+     * Verify professional certifications
+     */
+    public function verifyCertifications($user, $certifications)
+    {
+        $verifiedCerts = [];
+
+        foreach ($certifications as $cert) {
+            $verified = $this->verifyCertification($cert);
+            $verifiedCerts[] = [
+                'type' => $cert['type'],
+                'number' => $cert['number'],
+                'issuer' => $cert['issuer'],
+                'verified' => $verified,
+                'expiry_date' => $cert['expiry_date'],
+            ];
+        }
+
+        return $verifiedCerts;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\V1\JobController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\MapsController;
+use App\Http\Controllers\KYCController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -24,3 +25,8 @@ Route::prefix('v1')->group(function () {
 });
 
 Route::post('maps/geocode', [MapsController::class, 'geocode']);
+
+Route::prefix('kyc')->middleware('auth:sanctum')->group(function () {
+    Route::post('verify-document', [KYCController::class, 'verifyDocument']);
+    Route::post('background-check', [KYCController::class, 'initiateBackgroundCheck']);
+});


### PR DESCRIPTION
## Summary
- implement `KYCService` for handling document verification and background checks
- add `KYCController` with endpoints for document verification and background checks
- create `VerificationDocument` model
- register new API routes for KYC features

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6871931a280c832eb92ab0b8bee55770