### PR TITLE
Implement fraud detection service

### DIFF
--- a/app/Mail/SuspiciousActivityAlert.php
+++ b/app/Mail/SuspiciousActivityAlert.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class SuspiciousActivityAlert extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * The content for the email.
+     *
+     * @var array
+     */
+    public $content;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param  array  $content
+     * @return void
+     */
+    public function __construct(array $content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->subject('Kynderway - Suspicious Activity Detected')
+                    ->markdown('emails.suspicious-activity')
+                    ->with('content', $this->content);
+    }
+}

--- a/app/Services/FraudDetectionService.php
+++ b/app/Services/FraudDetectionService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\SuspiciousActivityAlert;
+
+class FraudDetectionService
+{
+    /**
+     * Check for suspicious activity for the given user.
+     *
+     * @param  \App\Models\User  $user
+     * @return array
+     */
+    public function checkUserActivity(User $user): array
+    {
+        $flags = [];
+
+        // Check for rapid account creation from same IP
+        $recentAccounts = User::where('ip_address', $user->ip_address)
+            ->where('created_at', '>', now()->subHours(24))
+            ->count();
+
+        if ($recentAccounts > 3) {
+            $flags[] = 'multiple_accounts_same_ip';
+        }
+
+        // Check for unusual booking patterns
+        if (method_exists($user, 'bookings')) {
+            $recentBookings = $user->bookings()
+                ->where('created_at', '>', now()->subHours(1))
+                ->count();
+
+            if ($recentBookings > 5) {
+                $flags[] = 'rapid_booking_creation';
+            }
+        }
+
+        // Check for payment anomalies
+        if (method_exists($user, 'transactions')) {
+            $failedPayments = $user->transactions()
+                ->where('status', 'failed')
+                ->where('created_at', '>', now()->subDays(7))
+                ->count();
+
+            if ($failedPayments > 10) {
+                $flags[] = 'excessive_payment_failures';
+            }
+        }
+
+        // Store flags and notify admin
+        if (!empty($flags)) {
+            Cache::put("fraud_flags:{$user->id}", $flags, now()->addDays(7));
+            $this->notifyAdminOfSuspiciousActivity($user, $flags);
+        }
+
+        return $flags;
+    }
+
+    /**
+     * Notify administrators when suspicious activity is detected.
+     */
+    protected function notifyAdminOfSuspiciousActivity(User $user, array $flags): void
+    {
+        $adminEmail = Config::get('kinderway.emailOptions.adminEmail');
+
+        Mail::to($adminEmail)->send(new SuspiciousActivityAlert([
+            'user' => $user,
+            'flags' => $flags,
+        ]));
+    }
+}

--- a/resources/views/emails/suspicious-activity.blade.php
+++ b/resources/views/emails/suspicious-activity.blade.php
@@ -1,0 +1,12 @@
+@component('mail::message')
+Suspicious activity has been detected for user **{{ $content['user']->email }}**.
+
+@foreach ($content['flags'] as $flag)
+- {{ $flag }}
+@endforeach
+
+Please review this account as soon as possible.
+
+Regards,<br>
+{{ config('app.name') }} Team
+@endcomponent


### PR DESCRIPTION
## Summary
- add `FraudDetectionService` for monitoring suspicious actions
- notify admins with new `SuspiciousActivityAlert` mail
- add markdown email template for the alert

## Testing
- `composer lint` *(fails: "composer.json" does not contain valid JSON)*
- `./vendor/bin/phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_687193587500832ea715e0442dd991cc