### PR TITLE
Add VacationCare search endpoint

### DIFF
--- a/app/Http/Controllers/Api/VacationCareController.php
+++ b/app/Http/Controllers/Api/VacationCareController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\GoogleMapsService;
+use Illuminate\Http\Request;
+use App\Models\User;
+
+class VacationCareController extends Controller
+{
+    private $mapsService;
+
+    public function __construct(GoogleMapsService $mapsService)
+    {
+        $this->mapsService = $mapsService;
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/vacation-care/search",
+     *     summary="Search for nannies in vacation location",
+     *     @OA\RequestBody(
+     *         @OA\JsonContent(
+     *             @OA\Property(property="destination", type="string"),
+     *             @OA\Property(property="start_date", type="string", format="date"),
+     *             @OA\Property(property="end_date", type="string", format="date"),
+     *             @OA\Property(property="children_ages", type="array", @OA\Items(type="integer")),
+     *             @OA\Property(property="care_schedule", type="object"),
+     *             @OA\Property(property="accommodation_type", type="string"),
+     *             @OA\Property(property="special_requirements", type="string")
+     *         )
+     *     )
+     * )
+     */
+    public function searchVacationNannies(Request $request)
+    {
+        $request->validate([
+            'destination' => 'required|string',
+            'start_date' => 'required|date|after:today',
+            'end_date' => 'required|date|after:start_date',
+            'children_ages' => 'required|array',
+            'care_schedule' => 'required|array',
+        ]);
+
+        // Placeholder: implement search logic using services
+        $localNannies = [];
+        $travelingNannies = [];
+        $destinationInsights = $this->getDestinationInsights($request->destination);
+
+        return response()->json([
+            'local_nannies' => $localNannies,
+            'traveling_nannies' => $travelingNannies,
+            'destination_insights' => $destinationInsights,
+            'estimated_local_rates' => $this->estimateLocalRates($request->destination),
+        ]);
+    }
+
+    private function searchTravelingNannies($origin, $destination, $criteria)
+    {
+        return User::query()
+            ->role('nanny')
+            ->where('is_active', true)
+            ->where('willing_to_travel', true)
+            ->get();
+    }
+
+    private function getDestinationInsights($destination)
+    {
+        $coords = $this->mapsService->geocodeAddress($destination);
+
+        return [
+            'average_hourly_rate' => $this->getAverageRate($coords),
+            'available_nannies_count' => $this->getAvailableNanniesCount($coords),
+            'popular_certifications' => $this->getPopularCertifications($coords),
+            'local_regulations' => $this->getLocalChildcareRegulations($coords),
+            'emergency_contacts' => $this->getEmergencyContacts($coords),
+        ];
+    }
+
+    // The following helper methods are placeholders for demonstration
+    private function estimateLocalRates($destination)
+    {
+        return [];
+    }
+
+    private function getAverageRate($coords)
+    {
+        return 0;
+    }
+
+    private function getAvailableNanniesCount($coords)
+    {
+        return 0;
+    }
+
+    private function getPopularCertifications($coords)
+    {
+        return [];
+    }
+
+    private function getLocalChildcareRegulations($coords)
+    {
+        return '';
+    }
+
+    private function getEmergencyContacts($coords)
+    {
+        return [];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\V1\JobController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\MapsController;
+use App\Http\Controllers\Api\VacationCareController;
 use App\Http\Controllers\KYCController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -25,6 +26,7 @@ Route::prefix('v1')->group(function () {
 });
 
 Route::post('maps/geocode', [MapsController::class, 'geocode']);
+Route::post('vacation-care/search', [VacationCareController::class, 'searchVacationNannies']);
 
 Route::prefix('kyc')->middleware('auth:sanctum')->group(function () {
     Route::post('verify-document', [KYCController::class, 'verifyDocument']);

--- a/tests/Feature/VacationCareTest.php
+++ b/tests/Feature/VacationCareTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\GoogleMapsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VacationCareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_vacation_care_search_returns_success()
+    {
+        $service = $this->createMock(GoogleMapsService::class);
+        $service->method('geocodeAddress')->willReturn(['lat' => 0, 'lng' => 0]);
+        app()->instance(GoogleMapsService::class, $service);
+
+        $response = $this->postJson('/api/vacation-care/search', [
+            'destination' => 'London',
+            'start_date' => now()->addDay()->toDateString(),
+            'end_date' => now()->addDays(2)->toDateString(),
+            'children_ages' => [5],
+            'care_schedule' => [],
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure([
+            'local_nannies',
+            'traveling_nannies',
+            'destination_insights',
+            'estimated_local_rates',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- create `VacationCareController` with placeholder logic
- add `/api/vacation-care/search` route
- test new endpoint with `VacationCareTest`

## Testing
- `composer lint` *(fails: `"./composer.json" does not contain valid JSON`)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68719692d4ac832e893f7a40a9641de9