### PR TITLE
Add JWT-protected profile unlock API

### DIFF
--- a/app/Http/Controllers/Api/BrowseController.php
+++ b/app/Http/Controllers/Api/BrowseController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\CreditService;
+use Illuminate\Http\Request;
+
+class BrowseController extends Controller
+{
+    private CreditService $credits;
+
+    public function __construct(CreditService $credits)
+    {
+        $this->credits = $credits;
+    }
+
+    public function unlockNanny(Request $request, $id)
+    {
+        $user = $request->user();
+        if (!$user) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $nanny = User::find($id);
+        if (!$nanny) {
+            return response()->json(['message' => 'Nanny not found'], 404);
+        }
+
+        if (!$this->credits->hasEnoughCredits($user)) {
+            return response()->json(['message' => 'Insufficient credits'], 400);
+        }
+
+        $this->credits->deductCredits($user);
+
+        return response()->json([
+            'success' => true,
+            'nanny' => $nanny,
+            'remaining_credits' => $user->credits,
+        ]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -69,5 +69,6 @@ class Kernel extends HttpKernel
         'is_client' => \App\Http\Middleware\isClient::class,
         'is_provider' => \App\Http\Middleware\isProvider::class,
         'api_key' => \App\Http\Middleware\ValidateApiKey::class,
+        'jwt.auth' => \App\Http\Middleware\JwtMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/JwtMiddleware.php
+++ b/app/Http/Middleware/JwtMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Exception;
+
+class JwtMiddleware
+{
+    public function handle($request, Closure $next)
+    {
+        $authHeader = $request->header('Authorization');
+        if (!$authHeader || !preg_match('/Bearer\s+(.*)/', $authHeader, $matches)) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $token = $matches[1];
+        $payload = $this->decodeJwt($token);
+        if (!$payload || empty($payload['sub'])) {
+            return response()->json(['message' => 'Invalid token'], 401);
+        }
+
+        $user = User::find($payload['sub']);
+        if (!$user) {
+            return response()->json(['message' => 'User not found'], 401);
+        }
+
+        auth()->setUser($user);
+        $request->setUserResolver(function () use ($user) {
+            return $user;
+        });
+
+        return $next($request);
+    }
+
+    private function decodeJwt(string $jwt): ?array
+    {
+        $parts = explode('.', $jwt);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$header64, $payload64, $signature64] = $parts;
+        $payload = json_decode($this->base64UrlDecode($payload64), true);
+        $header = json_decode($this->base64UrlDecode($header64), true);
+        if (!$payload || !$header) {
+            return null;
+        }
+
+        $expected = hash_hmac('sha256', $header64 . '.' . $payload64, env('JWT_SECRET', ''), true);
+        $signature = $this->base64UrlDecode($signature64);
+        if (!hash_equals($expected, $signature)) {
+            return null;
+        }
+
+        return $payload;
+    }
+
+    private function base64UrlDecode(string $input): string
+    {
+        $remainder = strlen($input) % 4;
+        if ($remainder) {
+            $input .= str_repeat('=', 4 - $remainder);
+        }
+        return base64_decode(strtr($input, '-_', '+/'));
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -73,7 +73,8 @@ class User extends Authenticatable implements MustVerifyEmail
         'delete_request',
         'otp',
         'otp_send_at',
-        'is_new'
+        'is_new',
+        'credits'
     ];
 
     /**

--- a/app/Services/CreditService.php
+++ b/app/Services/CreditService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class CreditService
+{
+    const UNLOCK_COST = 5;
+
+    public function hasEnoughCredits(User $user, int $cost = self::UNLOCK_COST): bool
+    {
+        return $user->credits >= $cost;
+    }
+
+    public function deductCredits(User $user, int $cost = self::UNLOCK_COST): void
+    {
+        $user->credits -= $cost;
+        $user->save();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "laravel/framework": "^8.12",
         "laravel/sanctum": "^2.15",
         "laravel/socialite": "^5.2",
-        "laravel/tinker": "^2.5",
+        "laravel/tinker": "^2.5"
 
 
     },

--- a/database/migrations/2025_07_12_000001_add_credits_to_users_table.php
+++ b/database/migrations/2025_07_12_000001_add_credits_to_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'credits')) {
+                $table->unsignedInteger('credits')->default(0);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'credits')) {
+                $table->dropColumn('credits');
+            }
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,3 +30,5 @@ Route::prefix('kyc')->middleware('auth:sanctum')->group(function () {
     Route::post('verify-document', [KYCController::class, 'verifyDocument']);
     Route::post('background-check', [KYCController::class, 'initiateBackgroundCheck']);
 });
+
+Route::middleware('jwt.auth')->post('unlock-nanny/{id}', [\App\Http\Controllers\Api\BrowseController::class, 'unlockNanny']);


### PR DESCRIPTION
## Summary
- create `CreditService` for basic credit handling
- add JWT middleware and register as `jwt.auth`
- implement `BrowseController` with `unlockNanny` action
- add credits column migration
- expose new `/api/unlock-nanny/{id}` route
- allow `credits` mass assignment
- fix trailing comma in composer.json

## Testing
- `php -l app/Services/CreditService.php`
- `php -l app/Http/Middleware/JwtMiddleware.php`
- `php -l app/Http/Controllers/Api/BrowseController.php`
- `php -l app/Models/User.php`
- `php -l routes/api.php`
- `php -l database/migrations/2025_07_12_000001_add_credits_to_users_table.php`
- `composer run lint` *(fails: composer.lock invalid)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687196b2e490832eb7c5b1afd83360e2