### PR TITLE
Fix GoogleMapsService methods

### DIFF
--- a/app/Services/GoogleMapsService.php
+++ b/app/Services/GoogleMapsService.php
@@ -15,13 +15,34 @@ class GoogleMapsService
             ->setParam(['address' => $address])
             ->get();
 
-        if ($result->status === 'OK') {
+        $result = json_decode($response);
+
+        if ($result && $result->status === 'OK') {
+            $components = $result->results[0]->address_components;
+            $city = null;
+            $postcode = null;
+
+            foreach ($components as $component) {
+                if (in_array('locality', $component->types, true)) {
+                    $city = $component->long_name;
+                }
+
+                if (in_array('postal_code', $component->types, true)) {
+                    $postcode = $component->long_name;
+                }
+            }
+
             return [
                 'lat' => $result->results[0]->geometry->location->lat,
                 'lng' => $result->results[0]->geometry->location->lng,
                 'formatted_address' => $result->results[0]->formatted_address,
+                'city' => $city,
+                'postcode' => $postcode,
             ];
         }
+
+        return null;
+    }
 
     /**
      * Get nearby places
@@ -36,6 +57,29 @@ class GoogleMapsService
             ])
             ->get();
 
+        $result = json_decode($response);
+
+        if ($result && $result->status === 'OK') {
+            $places = [];
+
+            foreach ($result->results as $place) {
+                $places[] = [
+                    'name' => $place->name,
+                    'location' => [
+                        'lat' => $place->geometry->location->lat,
+                        'lng' => $place->geometry->location->lng,
+                    ],
+                    'vicinity' => $place->vicinity ?? null,
+                    'place_id' => $place->place_id ?? null,
+                ];
+            }
+
+            return $places;
+        }
+
+        return null;
+    }
+
     /**
      * Calculate distance between two points
      */
@@ -49,6 +93,21 @@ class GoogleMapsService
             ])
             ->get();
 
-        return json_decode($response);
+        $result = json_decode($response);
+
+        if ($result && $result->status === 'OK') {
+            $element = $result->rows[0]->elements[0] ?? null;
+
+            if ($element && isset($element->distance, $element->duration)) {
+                return [
+                    'distance_text' => $element->distance->text,
+                    'distance_value' => $element->distance->value,
+                    'duration_text' => $element->duration->text,
+                    'duration_value' => $element->duration->value,
+                ];
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- close methods and decode Google Maps API responses
- return structured output and `null` on failure

## Testing
- `composer install`
- `php vendor/bin/phpunit --stop-on-failure` *(fails: BadMethodCallException)*

------
https://chatgpt.com/codex/tasks/task_b_6871a1de91c4832e8683fd9ae1d18130