### PR TITLE
Cleanup TODO comments in controllers

### DIFF
--- a/app/Http/Controllers/GuestController.php
+++ b/app/Http/Controllers/GuestController.php
@@ -25,8 +25,6 @@ use Carbon\Carbon;
 
 use Response;
 use Session;
-//TODO: remove it
-use Illuminate\Support\Facades\Log;
 
 class GuestController extends Controller
 {

--- a/app/Http/Controllers/ProviderController.php
+++ b/app/Http/Controllers/ProviderController.php
@@ -1250,13 +1250,7 @@ class ProviderController extends Controller
                 'providerFullname' => Auth::user()->name,
                 'dashboardUrl' => $dashboardUrl,
                 ];
-            //TODO: remove it on staging
             Mail::to($sendMailTo)->send(new ProviderConnect($senddetails));
-
-            // Mail::send('emails.provider-connect', $senddetails, function ($message) use ($sendMailTo)
-            // {
-            //     $message->to($sendMailTo)->subject('You have a new Job Application');
-            // });
         }
 
         //-------------------------------------------Email End-----------------------------------


### PR DESCRIPTION
## Summary
- remove unused `Log` import from `GuestController`
- delete stale TODO marker in `ProviderController`
- remove commented debug mail code

## Testing
- `composer lint` *(fails: php-cs-fixer not found)*
- `vendor/bin/phpunit` *(fails: BadMethodCallException, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_b_6871a3f20118832e9ef9384d458ceeec