### PR TITLE
Restrict /clear route to local environment

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -26,16 +26,18 @@ use Illuminate\Support\Facades\Auth;
 */
 
 
-Route::get('/clear', function () {   //optimized
-    Artisan::call('cache:clear');
-    Artisan::call('config:clear');
-    Artisan::call('config:cache');
-    Artisan::call('route:cache');
-    Artisan::call('route:clear');
-    Artisan::call('view:clear');
-    Artisan::call('view:cache');
-    return '<h1>Cache cleared</h1>';
-});
+if (app()->environment('local')) {
+    Route::get('/clear', function () {
+        Artisan::call('cache:clear');
+        Artisan::call('config:clear');
+        Artisan::call('config:cache');
+        Artisan::call('route:cache');
+        Artisan::call('route:clear');
+        Artisan::call('view:clear');
+        Artisan::call('view:cache');
+        return '<h1>Cache cleared</h1>';
+    });
+}
 
 
 Route::get('/get-unseen-message-count', function (Request $request) {


### PR DESCRIPTION
## Summary
- ensure the `/clear` route for clearing caches is only registered in the local environment

## Testing
- `composer install`
- `vendor/bin/phpunit --testsuite Unit,Feature` *(fails: BadMethodCallException)*

------
https://chatgpt.com/codex/tasks/task_b_6871a63e8464832e8a6c1915005fceae