### PR TITLE
Add production deployment script

### DIFF
--- a/deploy/production.sh
+++ b/deploy/production.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Move to project root
+cd "$(dirname "$0")/.."
+
+# Pull latest changes from main branch
+git fetch origin
+git checkout main
+git pull origin main
+
+# Install PHP dependencies without development packages
+composer install --no-dev --optimize-autoloader
+
+# Run database migrations
+php artisan migrate --force
+
+# Cache configuration, routes, and views
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+
+# Restart queue workers
+php artisan queue:restart
+
+# Restart PHP-FPM service
+sudo systemctl restart php-fpm
+


### PR DESCRIPTION
## Summary
- add a `deploy/production.sh` to automate production deployment

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --testdox` *(fails: BadMethodCallException)*

------
https://chatgpt.com/codex/tasks/task_b_6871a7e045c8832e9784010e9a07b279