### PR TITLE
Update to PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       matrix:
-        php-version: [ '8.1', '8.2' ]
+        php-version: [ '8.2' ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.2-fpm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary
- bump PHP base image to 8.2
- use PHP 8.2 in CI and deployment workflows

## Testing
- `composer lint` *(fails: LogicException)*
- `php artisan test` *(fails: 26 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6871a875540c832e812b3f2823e440c9