### PR TITLE
Add Terraform ECS setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+.terraform/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "task_definition" {
+  description = "Existing ECS task definition to run"
+  type        = string
+}
+
+resource "aws_ecs_cluster" "kynderway" {
+  name = "kynderway"
+}
+
+resource "aws_ecs_service" "kynderway_service" {
+  name            = "kynderway-service"
+  cluster         = aws_ecs_cluster.kynderway.id
+  task_definition = var.task_definition
+  desired_count   = 3
+}


### PR DESCRIPTION
## Summary
- add Terraform config for ECS cluster and service
- ignore `.terraform` directory

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Errors 25, Failures 1)*
- `terraform fmt -check terraform/main.tf`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_b_6871b4844b80832e8d27744f0c2bb0e9