### PR TITLE
Add Swagger annotations and tags

### DIFF
--- a/app/Http/Controllers/Api/ApiDocs.php
+++ b/app/Http/Controllers/Api/ApiDocs.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+/**
+ * @OA\Info(
+ *     title="Kynderway API",
+ *     version="1.0.0",
+ *     description="API documentation for Kynderway",
+ *     @OA\License(name="MIT", url="https://opensource.org/licenses/MIT")
+ * )
+ *
+ * @OA\SecurityScheme(
+ *     securityScheme="bearerAuth",
+ *     type="http",
+ *     scheme="bearer",
+ *     bearerFormat="JWT",
+ *     description="JWT based authentication"
+ * )
+ *
+ * @OA\Tag(
+ *     name="Authentication",
+ *     description="Operations related to authentication"
+ * )
+ * @OA\Tag(
+ *     name="Users",
+ *     description="Operations about users"
+ * )
+ * @OA\Tag(
+ *     name="Bookings",
+ *     description="Manage bookings"
+ * )
+ * @OA\Tag(
+ *     name="Credits",
+ *     description="Credit related endpoints"
+ * )
+ */
+class ApiDocs
+{
+    // This class is used for OpenAPI annotations only.
+}

--- a/app/Http/Controllers/Api/BrowseController.php
+++ b/app/Http/Controllers/Api/BrowseController.php
@@ -16,6 +16,22 @@ class BrowseController extends Controller
         $this->credits = $credits;
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/browse/nannies/{id}/unlock",
+     *     summary="Unlock nanny profile",
+     *     tags={"Credits"},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="ID of the nanny",
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(response=200, description="Successful unlock"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function unlockNanny(Request $request, $id)
     {
         $user = $request->user();

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -14,6 +14,7 @@ class AuthController extends Controller
      * @OA\Post(
      *     path="/api/mobile/login",
      *     summary="Mobile user login",
+     *     tags={"Authentication"},
      *     @OA\RequestBody(
      *         @OA\JsonContent(
      *             @OA\Property(property="email", type="string"),
@@ -59,6 +60,7 @@ class AuthController extends Controller
      * @OA\Post(
      *     path="/api/mobile/logout",
      *     summary="Mobile user logout",
+     *     tags={"Authentication"},
      *     security={{"sanctum": {}}},
      *     @OA\Response(response=200, description="Success")
      * )

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -6,25 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 
-/**
- * @OA\Info(
- *     title="Kynderway API",
- *     version="1.0.0",
- *     description="API documentation for Kynderway application",
- *     @OA\Contact(
- *         email="support@kynderway.com"
- *     ),
- *     @OA\License(
- *         name="MIT",
- *         url="https://opensource.org/licenses/MIT"
- *     )
- * )
- *
- * @OA\Server(
- *     url=L5_SWAGGER_CONST_HOST,
- *     description="API Server"
- * )
- */
+
 class UserController extends Controller
 {
     /**

--- a/app/Http/Controllers/Api/VacationCareController.php
+++ b/app/Http/Controllers/Api/VacationCareController.php
@@ -20,6 +20,7 @@ class VacationCareController extends Controller
      * @OA\Post(
      *     path="/api/vacation-care/search",
      *     summary="Search for nannies in vacation location",
+     *     tags={"Bookings"},
      *     @OA\RequestBody(
      *         @OA\JsonContent(
      *             @OA\Property(property="destination", type="string"),


### PR DESCRIPTION
## Summary
- define global OpenAPI annotations in `ApiDocs.php`
- tag auth, bookings and credits endpoints
- remove old duplicated info block from `UserController`

## Testing
- `composer lint` *(fails: php-cs-fixer not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871b7296ea8832e9fa71b8edc11c701