### PR TITLE
Add PaymentMethod model and migration

### DIFF
--- a/app/Models/PaymentMethod.php
+++ b/app/Models/PaymentMethod.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PaymentMethod extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'provider',
+        'type',
+        'last_four',
+        'exp_month',
+        'exp_year',
+        'stripe_payment_method_id',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -176,6 +176,11 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(CreditTransaction::class);
     }
 
+    public function paymentMethods()
+    {
+        return $this->hasMany(PaymentMethod::class);
+    }
+
     public function unlockedProfiles()
     {
         return $this->hasMany(UnlockedProfile::class, 'parent_id');

--- a/database/factories/PaymentMethodFactory.php
+++ b/database/factories/PaymentMethodFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PaymentMethod;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PaymentMethodFactory extends Factory
+{
+    protected $model = PaymentMethod::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'provider' => 'stripe',
+            'type' => 'card',
+            'last_four' => (string) $this->faker->numberBetween(1000, 9999),
+            'exp_month' => $this->faker->numberBetween(1, 12),
+            'exp_year' => $this->faker->numberBetween(date('Y'), date('Y') + 5),
+            'stripe_payment_method_id' => 'pm_' . $this->faker->unique()->lexify(str_repeat('?', 24)),
+        ];
+    }
+}

--- a/database/migrations/2025_08_01_000005_create_payment_methods_table.php
+++ b/database/migrations/2025_08_01_000005_create_payment_methods_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_methods', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('provider');
+            $table->string('type');
+            $table->string('last_four', 4);
+            $table->unsignedTinyInteger('exp_month');
+            $table->unsignedSmallInteger('exp_year');
+            $table->string('stripe_payment_method_id')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_methods');
+    }
+};


### PR DESCRIPTION
## Summary
- create `PaymentMethod` model with fillable fields
- add factory for payment methods
- create migration for `payment_methods` table
- link `User` with `PaymentMethod`

## Testing
- `vendor/bin/phpunit --testdox --colors=never` *(fails: Tests: 30, Assertions: 12, Errors: 25, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_b_6871b8dd32e8832eb045ca505093e7ab