### PR TITLE
Implement booking services and tests

### DIFF
--- a/app/Http/Controllers/Api/Mobile/BookingController.php
+++ b/app/Http/Controllers/Api/Mobile/BookingController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Booking;
+use App\Notifications\BookingRequestNotification;
+use App\Services\BookingService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Notification;
+
+class BookingController extends Controller
+{
+    public function store(Request $request, BookingService $service)
+    {
+        $data = $request->validate([
+            'parent_id'   => 'required|integer',
+            'nanny_id'    => 'required|integer',
+            'agency_id'   => 'nullable|integer',
+            'start_time'  => 'nullable|date',
+            'end_time'    => 'nullable|date',
+            'hours'       => 'required|integer',
+            'hourly_rate' => 'required|numeric',
+        ]);
+        $data['status'] = Booking::STATUS_REQUESTED;
+
+        $booking = $service->createBooking($data);
+
+        if (class_exists(BookingRequestNotification::class)) {
+            Notification::send($booking->nanny, new BookingRequestNotification($booking));
+        }
+
+        return response()->json($booking, 201);
+    }
+
+    public function complete(Booking $booking, BookingService $service)
+    {
+        $booking = $service->completeBooking($booking);
+
+        return response()->json($booking);
+    }
+}

--- a/app/Jobs/BookingAutoRejectJob.php
+++ b/app/Jobs/BookingAutoRejectJob.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Booking;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class BookingAutoRejectJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public Booking $booking)
+    {
+    }
+
+    public function handle()
+    {
+        if ($this->booking->status === Booking::STATUS_REQUESTED) {
+            $this->booking->update(['status' => Booking::STATUS_REJECTED]);
+        }
+    }
+}

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -9,7 +9,29 @@ class Booking extends Model
 {
     use HasFactory;
 
-    protected $guarded = [];
+    public const STATUS_REQUESTED = 'requested';
+    public const STATUS_ACCEPTED  = 'accepted';
+    public const STATUS_REJECTED  = 'rejected';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    protected $fillable = [
+        'parent_id',
+        'nanny_id',
+        'agency_id',
+        'start_time',
+        'end_time',
+        'hours',
+        'hourly_rate',
+        'status',
+    ];
+
+    protected $casts = [
+        'start_time' => 'datetime',
+        'end_time'   => 'datetime',
+        'hours'      => 'integer',
+        'hourly_rate'=> 'decimal:2',
+    ];
 
     public function agency()
     {

--- a/app/Notifications/BookingRequestNotification.php
+++ b/app/Notifications/BookingRequestNotification.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Booking;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class BookingRequestNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Booking $booking)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage())
+            ->subject('New Booking Request')
+            ->line('You have received a new booking request.');
+    }
+}

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Booking;
+use Illuminate\Support\Facades\DB;
+
+class BookingService
+{
+    public function __construct(protected PaymentService $paymentService)
+    {
+    }
+
+    public function createBooking(array $data): Booking
+    {
+        return DB::transaction(function () use ($data) {
+            $booking = Booking::create($data);
+            $this->paymentService->createEscrowPayment($booking);
+            return $booking->fresh();
+        });
+    }
+
+    public function completeBooking(Booking $booking): Booking
+    {
+        $this->paymentService->releasePayment($booking);
+        $booking->update(['status' => Booking::STATUS_COMPLETED]);
+
+        return $booking->fresh();
+    }
+}

--- a/database/migrations/2024_07_01_000000_create_bookings_table.php
+++ b/database/migrations/2024_07_01_000000_create_bookings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBookingsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('bookings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('parent_id');
+            $table->unsignedBigInteger('nanny_id');
+            $table->unsignedBigInteger('agency_id')->nullable();
+            $table->timestamp('start_time')->nullable();
+            $table->timestamp('end_time')->nullable();
+            $table->integer('hours');
+            $table->decimal('hourly_rate', 8, 2);
+            $table->string('status')->default('requested');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('bookings');
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
             <file>./tests/Feature/CreditPurchaseTest.php</file>
             <file>./tests/Feature/ProfileUnlockTest.php</file>
             <file>./tests/Feature/PaymentProcessingTest.php</file>
+            <file>./tests/Feature/BookingFlowTest.php</file>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\Mobile\AuthController;
 use App\Http\Controllers\Api\Mobile\UserController;
+use App\Http\Controllers\Api\Mobile\BookingController;
 use Illuminate\Support\Facades\Route;
 
 // Public routes
@@ -13,4 +14,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/user', [UserController::class, 'profile']);
     Route::put('/user', [UserController::class, 'update']);
+
+    Route::post('/bookings', [BookingController::class, 'store']);
+    Route::post('/bookings/{booking}/complete', [BookingController::class, 'complete']);
 });

--- a/tests/Feature/BookingFlowTest.php
+++ b/tests/Feature/BookingFlowTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Notifications\BookingRequestNotification;
+use App\Services\BookingService;
+use App\Services\PaymentService;
+use App\Jobs\BookingAutoRejectJob;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+use Stripe\PaymentIntent;
+use Stripe\Transfer;
+use Tests\TestCase;
+
+class BookingFlowTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->string('remember_token')->nullable();
+            $table->string('stripe_account_id')->nullable();
+            $table->decimal('commission_rate', 5, 2)->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        Schema::create('bookings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('parent_id');
+            $table->unsignedBigInteger('nanny_id');
+            $table->unsignedBigInteger('agency_id')->nullable();
+            $table->timestamp('start_time')->nullable();
+            $table->timestamp('end_time')->nullable();
+            $table->integer('hours');
+            $table->decimal('hourly_rate', 8, 2);
+            $table->string('status')->default('requested');
+            $table->timestamps();
+        });
+
+        Schema::create('transactions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('booking_id');
+            $table->string('type');
+            $table->decimal('amount', 8, 2);
+            $table->decimal('subtotal', 8, 2);
+            $table->decimal('platform_fee', 8, 2);
+            $table->decimal('agency_fee', 8, 2);
+            $table->string('stripe_payment_intent_id');
+            $table->string('status');
+            $table->timestamp('released_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('transactions');
+        Schema::dropIfExists('bookings');
+        Schema::dropIfExists('users');
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_booking_creation_sends_notification()
+    {
+        Notification::fake();
+
+        $nanny = User::factory()->create();
+        $parent = User::factory()->create();
+
+        Mockery::mock('alias:' . PaymentIntent::class)
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn((object) ['id' => 'pi']);
+
+        $service = new BookingService(new PaymentService());
+        $booking = $service->createBooking([
+            'parent_id' => $parent->id,
+            'nanny_id' => $nanny->id,
+            'hours' => 2,
+            'hourly_rate' => 20,
+            'status' => Booking::STATUS_REQUESTED,
+        ]);
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'status' => Booking::STATUS_REQUESTED,
+        ]);
+        $this->assertDatabaseHas('transactions', [
+            'booking_id' => $booking->id,
+        ]);
+    }
+
+    public function test_auto_reject_job_changes_status()
+    {
+        $nanny = User::factory()->create();
+        $parent = User::factory()->create();
+
+        $booking = Booking::create([
+            'parent_id' => $parent->id,
+            'nanny_id' => $nanny->id,
+            'hours' => 1,
+            'hourly_rate' => 10,
+            'status' => Booking::STATUS_REQUESTED,
+        ]);
+
+        (new BookingAutoRejectJob($booking))->handle();
+
+        $this->assertEquals(Booking::STATUS_REJECTED, $booking->fresh()->status);
+    }
+
+    public function test_complete_booking_releases_payment()
+    {
+        $nanny = User::factory()->create(['stripe_account_id' => 'acct_nanny']);
+        $parent = User::factory()->create();
+
+        Mockery::mock('alias:' . PaymentIntent::class)
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn((object) ['id' => 'pi']);
+
+        $service = new BookingService(new PaymentService());
+        $booking = $service->createBooking([
+            'parent_id' => $parent->id,
+            'nanny_id' => $nanny->id,
+            'hours' => 3,
+            'hourly_rate' => 30,
+            'status' => Booking::STATUS_REQUESTED,
+        ]);
+
+        Mockery::mock('alias:' . Transfer::class)
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn((object) ['id' => 'tr']);
+
+        $service->completeBooking($booking);
+
+        $this->assertDatabaseHas('transactions', [
+            'booking_id' => $booking->id,
+            'status' => 'completed',
+        ]);
+        $this->assertEquals(Booking::STATUS_COMPLETED, $booking->fresh()->status);
+    }
+}


### PR DESCRIPTION
## Summary
- define booking status constants and casts
- create bookings table migration
- implement BookingService
- notify nanny about booking request and auto rejection job
- expose booking API endpoints
- add tests for booking flow

## Testing
- `php artisan test --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_6871c2a26614832ebaa530380978044c