### PR TITLE
Implement credit service API

### DIFF
--- a/app/Http/Controllers/Api/BrowseController.php
+++ b/app/Http/Controllers/Api/BrowseController.php
@@ -44,11 +44,11 @@ class BrowseController extends Controller
             return response()->json(['message' => 'Nanny not found'], 404);
         }
 
-        if (!$this->credits->hasEnoughCredits($user, 3)) {
+        if (!$this->credits->hasEnoughCredits($user)) {
             return response()->json(['message' => 'Insufficient credits'], 400);
         }
 
-        $this->credits->deductCredits($user, 3);
+        $this->credits->deductCredits($user);
 
         return response()->json([
             'success' => true,

--- a/tests/Unit/CreditServiceTest.php
+++ b/tests/Unit/CreditServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Models\UserCredit;
+use App\Models\CreditTransaction;
+use App\Services\CreditService;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class CreditServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->string('remember_token')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        Schema::create('user_credits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->integer('balance')->default(0);
+            $table->integer('lifetime_purchased')->default(0);
+            $table->integer('lifetime_used')->default(0);
+            $table->timestamp('last_purchase_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('credit_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->string('type');
+            $table->integer('amount');
+            $table->integer('balance_after');
+            $table->string('description');
+            $table->string('reference_type')->nullable();
+            $table->unsignedBigInteger('reference_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('credit_transactions');
+        Schema::dropIfExists('user_credits');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_has_enough_credits_returns_true_when_balance_sufficient()
+    {
+        $user = User::factory()->create();
+        UserCredit::create(['user_id' => $user->id, 'balance' => 5]);
+
+        $service = new CreditService();
+
+        $this->assertTrue($service->hasEnoughCredits($user));
+    }
+
+    public function test_has_enough_credits_returns_false_when_balance_low()
+    {
+        $user = User::factory()->create();
+        UserCredit::create(['user_id' => $user->id, 'balance' => 1]);
+
+        $service = new CreditService();
+
+        $this->assertFalse($service->hasEnoughCredits($user));
+    }
+
+    public function test_deduct_credits_updates_balance_and_logs_transaction()
+    {
+        $user = User::factory()->create();
+        UserCredit::create([
+            'user_id' => $user->id,
+            'balance' => 5,
+            'lifetime_purchased' => 5,
+            'lifetime_used' => 0,
+        ]);
+
+        Event::fake();
+
+        $service = new CreditService();
+        $service->deductCredits($user);
+
+        $this->assertDatabaseHas('user_credits', [
+            'user_id' => $user->id,
+            'balance' => 2,
+            'lifetime_used' => 3,
+        ]);
+
+        $this->assertDatabaseHas('credit_transactions', [
+            'user_id' => $user->id,
+            'type' => 'use',
+            'amount' => -3,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- update `BrowseController` to use new credit service API
- simplify credit operations in `CreditService`
- add `CreditServiceTest`

## Testing
- `./vendor/bin/phpunit --filter CreditServiceTest tests/Unit/CreditServiceTest.php`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_6871d7e1c7d8832eab8cce9fbfebcd6a