### PR TITLE
Add mobile API feature tests

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -30,6 +31,7 @@ use Illuminate\Support\Facades\Mail;
 class User extends Authenticatable implements MustVerifyEmail
 {
     use HasFactory;
+    use HasApiTokens;
     use Notifiable;
     use SoftDeletes;
     use \App\Traits\Geocodable;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
             <file>./tests/Feature/ProfileUnlockTest.php</file>
             <file>./tests/Feature/PaymentProcessingTest.php</file>
             <file>./tests/Feature/BookingFlowTest.php</file>
+            <file>./tests/Feature/MobileApiTest.php</file>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/tests/Feature/MobileApiTest.php
+++ b/tests/Feature/MobileApiTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class MobileApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mobile_user_can_login_access_routes_and_logout(): void
+    {
+        $user = User::factory()->create(['password' => bcrypt('secret')]);
+
+        $login = $this->postJson('/api/mobile/v1/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+            'device_name' => 'testing',
+        ]);
+
+        $login->assertOk()->assertJsonStructure(['token', 'user']);
+        $token = $login->json('token');
+
+        $home = $this->withToken($token)->getJson('/api/mobile/v1/home');
+        $home->assertOk()->assertJson(['message' => 'Welcome to the mobile API']);
+
+        $this->withToken($token)->postJson('/api/mobile/v1/logout')->assertOk();
+    }
+
+    public function test_login_fails_with_invalid_credentials(): void
+    {
+        $user = User::factory()->create(['password' => bcrypt('secret')]);
+
+        $response = $this->postJson('/api/mobile/v1/login', [
+            'email' => $user->email,
+            'password' => 'wrong',
+            'device_name' => 'testing',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_mobile_endpoints_require_authentication(): void
+    {
+        $this->getJson('/api/mobile/v1/home')->assertUnauthorized();
+        $this->postJson('/api/mobile/v1/device/register', ['token' => 't'])->assertUnauthorized();
+    }
+
+    public function test_mobile_api_rate_limiter_uses_user_or_ip(): void
+    {
+        $user = User::factory()->make(['id' => 9]);
+        $request = Request::create('/api/mobile/v1/home', 'GET', [], [], [], ['REMOTE_ADDR' => '1.1.1.1']);
+        $request->setUserResolver(fn () => $user);
+
+        $limiter = RateLimiter::limiter('mobile-api');
+        $limit = $limiter($request);
+
+        $this->assertEquals(100, $limit->maxAttempts);
+        $this->assertEquals(1, $limit->decayMinutes);
+        $this->assertEquals($user->id, $limit->key);
+
+        $guest = Request::create('/api/mobile/v1/home', 'GET', [], [], [], ['REMOTE_ADDR' => '2.2.2.2']);
+        $guest->setUserResolver(fn () => null);
+
+        $limitGuest = $limiter($guest);
+        $this->assertEquals('2.2.2.2', $limitGuest->key);
+    }
+}


### PR DESCRIPTION
## Summary
- implement Sanctum API tokens in `User` model
- add PHPUnit coverage for new mobile login/logout endpoints
- verify mobile API rate limiting and authentication
- register new test file in phpunit config

## Testing
- `./vendor/bin/phpunit tests/Feature/MobileApiTest.php --stop-on-failure --testdox`


------
https://chatgpt.com/codex/tasks/task_b_6871db4e7ad4832e98b847f9e91e50ec