### PR TITLE
Enable Prometheus metrics

### DIFF
--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Prometheus\CollectorRegistry;
+use Prometheus\RenderTextFormat;
+
+class MetricsController extends Controller
+{
+    private CollectorRegistry $registry;
+
+    public function __construct(CollectorRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    public function __invoke()
+    {
+        $renderer = new RenderTextFormat();
+        $metrics = $this->registry->getMetricFamilySamples();
+        $result = $renderer->render($metrics);
+
+        return response($result, 200)->header('Content-Type', RenderTextFormat::MIME_TYPE);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -44,6 +44,7 @@ class Kernel extends HttpKernel
             \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            'metrics',
         ],
     ];
 
@@ -70,5 +71,6 @@ class Kernel extends HttpKernel
         'is_provider' => \App\Http\Middleware\isProvider::class,
         'api_key' => \App\Http\Middleware\ValidateApiKey::class,
         'jwt.auth' => \App\Http\Middleware\JwtMiddleware::class,
+        'metrics' => \App\Http\Middleware\PrometheusMetrics::class,
     ];
 }

--- a/app/Http/Middleware/PrometheusMetrics.php
+++ b/app/Http/Middleware/PrometheusMetrics.php
@@ -45,6 +45,13 @@ class PrometheusMetrics
             $request->path()
         ]);
 
+        $gauge = $this->registry->getOrRegisterGauge(
+            'kynderway',
+            'app_memory_usage_bytes',
+            'Memory usage in bytes'
+        );
+        $gauge->set(memory_get_usage(true));
+
         return $response;
     }
 }

--- a/app/Providers/PrometheusServiceProvider.php
+++ b/app/Providers/PrometheusServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Prometheus\CollectorRegistry;
+use Prometheus\Storage\InMemory;
+
+class PrometheusServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(CollectorRegistry::class, function () {
+            return new CollectorRegistry(new InMemory());
+        });
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -66,6 +66,10 @@ class RouteServiceProvider extends ServiceProvider
             Route::middleware('web')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/admin.php'));
+
+            Route::middleware('metrics')
+                ->namespace($this->namespace)
+                ->group(base_path('routes/metrics.php'));
         });
     }
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "laravel/sanctum": "^2.15",
     "laravel/socialite": "^5.2",
     "laravel/tinker": "^2.5",
+    "promphp/prometheus_client_php": "^2.14",
     "stripe/stripe-php": "^10.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3078eee4835d9b558312147e0c007ae4",
+    "content-hash": "f8fd6d1f1e8f56d4e643750fdd937240",
     "packages": [
         {
             "name": "alexpechkarev/geometry-library",
@@ -3393,6 +3393,74 @@
                 }
             ],
             "time": "2025-06-26T16:29:55+00:00"
+        },
+        {
+            "name": "promphp/prometheus_client_php",
+            "version": "v2.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PromPHP/prometheus_client_php.git",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/a283aea8269287dc35313a0055480d950c59ac1f",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "endclothing/prometheus_client_php": "*",
+                "jimdo/prometheus_client_php": "*",
+                "lkaemmerling/prometheus_client_php": "*"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5.4",
+                "phpstan/phpstan-phpunit": "^1.1.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/polyfill-apcu": "^1.6"
+            },
+            "suggest": {
+                "ext-apc": "Required if using APCu.",
+                "ext-pdo": "Required if using PDO.",
+                "ext-redis": "Required if using Redis.",
+                "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
+                "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prometheus\\": "src/Prometheus/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lukas Kämmerling",
+                    "email": "kontakt@lukas-kaemmerling.de"
+                }
+            ],
+            "description": "Prometheus instrumentation library for PHP applications.",
+            "support": {
+                "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.14.1"
+            },
+            "time": "2025-04-14T07:59:43+00:00"
         },
         {
             "name": "psr/cache",
@@ -11725,13 +11793,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.3|^8.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },

--- a/config/app.php
+++ b/config/app.php
@@ -174,6 +174,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\PrometheusServiceProvider::class,
         // Barryvdh\Debugbar\ServiceProvider::class,
 
     ],

--- a/routes/metrics.php
+++ b/routes/metrics.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\MetricsController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/metrics', MetricsController::class);


### PR DESCRIPTION
## Summary
- install promphp/prometheus_client_php
- collect request metrics via middleware
- register middleware for API routes
- expose metrics endpoint
- bind `CollectorRegistry` in service provider

## Testing
- `composer lint` *(fails: Finder logic exception)*
- `composer lint:phpstan` *(fails: Fatal error in PHPStan)*
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_6871e33dff1c832eb146e61cd0f41415