### PR TITLE
Add FCM token support

### DIFF
--- a/app/Http/Controllers/Api/Mobile/DeviceController.php
+++ b/app/Http/Controllers/Api/Mobile/DeviceController.php
@@ -13,7 +13,10 @@ class DeviceController extends Controller
             'token' => 'required|string',
         ]);
 
-        // Store or update device token here
+        $user = $request->user();
+        $user->fcm_token = $request->token;
+        $user->save();
+
         return response()->json(['success' => true]);
     }
 
@@ -23,7 +26,12 @@ class DeviceController extends Controller
             'token' => 'required|string',
         ]);
 
-        // Remove device token here
+        $user = $request->user();
+        if ($user->fcm_token === $request->token) {
+            $user->fcm_token = null;
+            $user->save();
+        }
+
         return response()->json(['success' => true]);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,6 +69,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'provider',
         'provider_id',
+        'fcm_token',
         'assign_user_id',
         'deleted_by',
         'deleted_type',

--- a/database/migrations/2025_08_01_000006_add_fcm_token_to_users_table.php
+++ b/database/migrations/2025_08_01_000006_add_fcm_token_to_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'fcm_token')) {
+                $table->string('fcm_token')->nullable()->after('provider_id');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'fcm_token')) {
+                $table->dropColumn('fcm_token');
+            }
+        });
+    }
+};

--- a/docs/mobile-sdk.md
+++ b/docs/mobile-sdk.md
@@ -116,6 +116,8 @@ Response:
 { "success": true }
 ```
 
+Clients should call this endpoint whenever a new Firebase Cloud Messaging (FCM) token is issued. Sending the latest token ensures the server can deliver push notifications to the correct device.
+
 ### Unregister Device
 
 `POST /api/mobile/v1/device/unregister`


### PR DESCRIPTION
## Summary
- add migration for `users.fcm_token`
- allow updating FCM token via DeviceController
- allow mass-assigning `fcm_token` on User
- document registering the FCM token for push notifications

## Testing
- `./vendor/bin/phpunit --testsuite Unit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_6871e67f4738832eae2266504321210a