### PR TITLE
Refactor push notification service

### DIFF
--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -6,6 +6,7 @@ use App\Models\Booking;
 use Illuminate\Support\Facades\DB;
 
 use App\Services\PushNotificationService;
+use Kreait\Firebase\Messaging\Notification;
 
 class BookingService
 {
@@ -20,7 +21,18 @@ class BookingService
         return DB::transaction(function () use ($data) {
             $booking = Booking::create($data);
             $this->paymentService->createEscrowPayment($booking);
-            $this->notificationService->notifyNannyOfBooking($booking->nanny, $booking);
+
+            $this->notificationService->sendToDevice(
+                $booking->nanny->fcm_token,
+                [
+                    'booking_id' => $booking->id,
+                    'type' => 'new_booking',
+                ],
+                Notification::create(
+                    'New Booking Request',
+                    "{$booking->parent->name} has requested a booking"
+                )
+            );
             return $booking->fresh();
         });
     }
@@ -29,7 +41,19 @@ class BookingService
     {
         $this->paymentService->releasePayment($booking);
         $booking->update(['status' => Booking::STATUS_COMPLETED]);
-        $this->notificationService->notifyParentOfStatusChange($booking->parent, $booking);
+
+        $this->notificationService->sendToDevice(
+            $booking->parent->fcm_token,
+            [
+                'booking_id' => $booking->id,
+                'status' => $booking->status,
+                'type' => 'booking_status',
+            ],
+            Notification::create(
+                'Booking Update',
+                "Your booking with {$booking->nanny->name} is now {$booking->status}"
+            )
+        );
 
         return $booking->fresh();
     }

--- a/tests/Stubs/FirebaseStubs.php
+++ b/tests/Stubs/FirebaseStubs.php
@@ -7,6 +7,7 @@ class Factory {
 namespace Kreait\Firebase\Messaging;
 class MessagingStub {
     public function send($message){}
+    public function subscribeToTopic($topic, $token){}
 }
 class CloudMessage {
     public static function withTarget($type, $token){ return new static(); }

--- a/tests/Unit/PushNotificationServiceTest.php
+++ b/tests/Unit/PushNotificationServiceTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit;
 
 use App\Services\PushNotificationService;
-use App\Models\Booking;
 use Mockery;
 use Tests\TestCase;
 
@@ -11,9 +10,9 @@ require_once __DIR__ . '/../Stubs/FirebaseStubs.php';
 
 class PushNotificationServiceTest extends TestCase
 {
-    public function test_notify_nanny_of_booking_sends_message()
+    public function test_send_to_device_sends_message()
     {
-        $messaging = Mockery::mock('Kreait\Firebase\Messaging\MessagingStub');
+        $messaging = Mockery::mock('Kreait\\Firebase\\Messaging\\MessagingStub');
         $messaging->shouldReceive('send')->once();
 
         $service = (new \ReflectionClass(PushNotificationService::class))
@@ -22,28 +21,6 @@ class PushNotificationServiceTest extends TestCase
         $prop->setAccessible(true);
         $prop->setValue($service, $messaging);
 
-        $nanny = (object)['fcm_token' => 'token'];
-        $parent = (object)['name' => 'Parent'];
-        $booking = (object)['id' => 1, 'parent' => $parent];
-
-        $service->notifyNannyOfBooking($nanny, $booking);
-    }
-
-    public function test_notify_parent_of_status_change_sends_message()
-    {
-        $messaging = Mockery::mock('Kreait\Firebase\Messaging\MessagingStub');
-        $messaging->shouldReceive('send')->once();
-
-        $service = (new \ReflectionClass(PushNotificationService::class))
-            ->newInstanceWithoutConstructor();
-        $prop = new \ReflectionProperty(PushNotificationService::class, 'messaging');
-        $prop->setAccessible(true);
-        $prop->setValue($service, $messaging);
-
-        $parent = (object)['fcm_token' => 'token'];
-        $nanny = (object)['name' => 'Nanny'];
-        $booking = (object)['id' => 2, 'nanny' => $nanny, 'status' => Booking::STATUS_COMPLETED];
-
-        $service->notifyParentOfStatusChange($parent, $booking);
+        $service->sendToDevice('token', ['foo' => 'bar']);
     }
 }


### PR DESCRIPTION
## Summary
- add generic `sendToDevice`, `sendToTopic`, `subscribeToTopic`
- load Firebase messaging client via the container
- adjust booking service and job to use new API
- update tests and stubs accordingly

## Testing
- `./vendor/bin/phpunit --testsuite=Unit --stop-on-failure --colors=never`
- `./vendor/bin/phpunit --testsuite=Feature --stop-on-failure --colors=never`
- `./vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_b_6871e8887674832e8304454548279434