### PR TITLE
Add push notification channel

### DIFF
--- a/app/Notifications/BookingConfirmedNotification.php
+++ b/app/Notifications/BookingConfirmedNotification.php
@@ -8,7 +8,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Kreait\Firebase\Messaging\Notification as FcmNotification;
 
-class BookingRequestNotification extends Notification
+class BookingConfirmedNotification extends Notification
 {
     use Queueable;
 
@@ -24,8 +24,8 @@ class BookingRequestNotification extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage())
-            ->subject('New Booking Request')
-            ->line('You have received a new booking request.');
+            ->subject('Booking Confirmed')
+            ->line("Your booking with {$this->booking->nanny->name} has been accepted.");
     }
 
     public function toPush($notifiable): array
@@ -34,11 +34,11 @@ class BookingRequestNotification extends Notification
             'token' => $notifiable->fcm_token,
             'data' => [
                 'booking_id' => $this->booking->id,
-                'type' => 'booking_request',
+                'type' => 'booking_confirmed',
             ],
             'notification' => FcmNotification::create(
-                'New Booking Request',
-                'You have received a new booking request.'
+                'Booking Confirmed',
+                "Your booking with {$this->booking->nanny->name} has been accepted."
             ),
         ];
     }

--- a/app/Notifications/Channels/PushNotificationChannel.php
+++ b/app/Notifications/Channels/PushNotificationChannel.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Notifications\Channels;
+
+use App\Services\PushNotificationService;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Custom notification channel forwarding payloads to PushNotificationService.
+ *
+ * Example usage in a notification:
+ * ```php
+ * public function via($notifiable)
+ * {
+ *     return ['mail', 'push'];
+ * }
+ *
+ * public function toPush($notifiable)
+ * {
+ *     return [
+ *         'token' => $notifiable->fcm_token,
+ *         'data' => ['foo' => 'bar'],
+ *         'notification' => FcmNotification::create('Title', 'Body'),
+ *     ];
+ * }
+ * ```
+ */
+class PushNotificationChannel
+{
+    public function __construct(protected PushNotificationService $service)
+    {
+    }
+
+    public function send($notifiable, Notification $notification): void
+    {
+        if (!method_exists($notification, 'toPush')) {
+            return;
+        }
+
+        $payload = $notification->toPush($notifiable);
+
+        $token = $payload['token'] ?? ($notifiable->fcm_token ?? null);
+        $data = $payload['data'] ?? [];
+        $notif = $payload['notification'] ?? null;
+
+        if ($token) {
+            $this->service->sendToDevice($token, $data, $notif);
+        }
+    }
+}

--- a/app/Notifications/CreditsPurchasedNotification.php
+++ b/app/Notifications/CreditsPurchasedNotification.php
@@ -6,6 +6,7 @@ use App\Models\CreditPackage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Kreait\Firebase\Messaging\Notification as FcmNotification;
 
 class CreditsPurchasedNotification extends Notification
 {
@@ -17,7 +18,7 @@ class CreditsPurchasedNotification extends Notification
 
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['mail', 'push'];
     }
 
     public function toMail($notifiable)
@@ -25,5 +26,20 @@ class CreditsPurchasedNotification extends Notification
         return (new MailMessage())
             ->subject('Credits Purchased')
             ->line("You purchased {$this->credits} credits using package {$this->package->name}.");
+    }
+
+    public function toPush($notifiable): array
+    {
+        return [
+            'token' => $notifiable->fcm_token,
+            'data' => [
+                'type' => 'credits_purchased',
+                'credits' => $this->credits,
+            ],
+            'notification' => FcmNotification::create(
+                'Credits Purchased',
+                "You purchased {$this->credits} credits using package {$this->package->name}."
+            ),
+        ];
     }
 }

--- a/app/Notifications/ProfileUnlockedNotification.php
+++ b/app/Notifications/ProfileUnlockedNotification.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Kreait\Firebase\Messaging\Notification as FcmNotification;
 
 class ProfileUnlockedNotification extends Notification
 {
@@ -17,7 +18,7 @@ class ProfileUnlockedNotification extends Notification
 
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['mail', 'push'];
     }
 
     public function toMail($notifiable)
@@ -25,5 +26,19 @@ class ProfileUnlockedNotification extends Notification
         return (new MailMessage())
             ->subject('Profile Unlocked')
             ->line("{$this->parent->name} has unlocked your profile.");
+    }
+
+    public function toPush($notifiable): array
+    {
+        return [
+            'token' => $notifiable->fcm_token,
+            'data' => [
+                'type' => 'profile_unlocked',
+            ],
+            'notification' => FcmNotification::create(
+                'Profile Unlocked',
+                "{$this->parent->name} has unlocked your profile."
+            ),
+        ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,8 @@ namespace App\Providers;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Notification;
+use App\Notifications\Channels\PushNotificationChannel;
 // use app/Notifications/EmailVerification;
 
 use Auth;
@@ -42,6 +44,9 @@ class AppServiceProvider extends ServiceProvider
     {
         Paginator::useBootstrap();
         Validator::extend('recaptcha', 'App\\Validators\\ReCaptcha@validate');
+        Notification::extend('push', function ($app) {
+            return $app->make(PushNotificationChannel::class);
+        });
 
         view()->composer('*', function ($view) {
             $user_type = '';

--- a/docs/mobile-sdk.md
+++ b/docs/mobile-sdk.md
@@ -248,3 +248,13 @@ Unauthenticated requests receive a `401` response using this format.
 ### Escrow and Auto-Reject
 - A payment intent is created and held in escrow when a booking is made. Funds are not released until the nanny completes the booking.
 - Bookings that remain in the `requested` status are automatically rejected by a background job, notifying the parent.
+
+### Push Notifications
+When a booking is confirmed a push notification is sent with this payload:
+```json
+{
+    "type": "booking_confirmed",
+    "booking_id": 42
+}
+```
+Include `push` in your notification's `via()` method and implement `toPush()` to return the token, data and FCM notification instance.

--- a/tests/Stubs/FirebaseStubs.php
+++ b/tests/Stubs/FirebaseStubs.php
@@ -2,6 +2,9 @@
 namespace Kreait\Firebase;
 class Factory {
     public function withServiceAccount($c){ return $this; }
+    public function withVerifierCache($cache){ return $this; }
+    public function withAuthTokenCache($cache){ return $this; }
+    public function withHttpClientOptions($opts){ return $this; }
     public function createMessaging(){ return new \Kreait\Firebase\Messaging\MessagingStub(); }
 }
 namespace Kreait\Firebase\Messaging;


### PR DESCRIPTION
## Summary
- add `BookingConfirmedNotification` with push channel support
- implement `PushNotificationChannel`
- extend existing notifications with `toPush`
- register the push channel in `AppServiceProvider`
- document push notification usage
- update Firebase stubs for tests

## Testing
- `php artisan test` *(fails: Call to undefined method withHttpClientOptions)*

------
https://chatgpt.com/codex/tasks/task_b_68721acdaebc832eac60b856eeb1bf50