### PR TITLE
Add push notification feature tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,7 @@
             <file>./tests/Feature/PaymentProcessingTest.php</file>
             <file>./tests/Feature/BookingFlowTest.php</file>
             <file>./tests/Feature/MobileApiTest.php</file>
+            <file>./tests/Feature/PushNotificationTest.php</file>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/tests/Feature/ProfileUnlockTest.php
+++ b/tests/Feature/ProfileUnlockTest.php
@@ -12,12 +12,17 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Tests\TestCase;
+use Kreait\Firebase\Messaging\MessagingStub;
+
+require_once __DIR__ . '/../Stubs/FirebaseStubs.php';
 
 class ProfileUnlockTest extends TestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
+
+        app()->instance('firebase.messaging', new MessagingStub());
 
         Schema::create('users', function (Blueprint $table) {
             $table->id();

--- a/tests/Feature/PushNotificationTest.php
+++ b/tests/Feature/PushNotificationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\PushNotificationService;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Kreait\Firebase\Messaging\MessagingStub;
+use Kreait\Firebase\Messaging\Notification;
+use Kreait\Firebase\Messaging\CloudMessage;
+use Tests\TestCase;
+
+require_once __DIR__ . '/../Stubs/FirebaseStubs.php';
+
+class PushNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function test_send_to_device_builds_message_and_sends(): void
+    {
+        $messaging = new MessagingStub();
+        $service = (new \ReflectionClass(PushNotificationService::class))
+            ->newInstanceWithoutConstructor();
+        $prop = new \ReflectionProperty(PushNotificationService::class, 'messaging');
+        $prop->setAccessible(true);
+        $prop->setValue($service, $messaging);
+
+        $service->sendToDevice('abc', ['foo' => 'bar'], Notification::create('t', 'b'));
+
+        $message = $messaging->sentMessage;
+        $this->assertInstanceOf(CloudMessage::class, $message);
+        $this->assertEquals('token', $message->targetType);
+        $this->assertEquals('abc', $message->target);
+        $this->assertEquals(['foo' => 'bar'], $message->data);
+        $this->assertInstanceOf(Notification::class, $message->notification);
+    }
+
+    public function test_send_to_topic_builds_message_and_sends(): void
+    {
+        $messaging = new MessagingStub();
+        $service = (new \ReflectionClass(PushNotificationService::class))
+            ->newInstanceWithoutConstructor();
+        $prop = new \ReflectionProperty(PushNotificationService::class, 'messaging');
+        $prop->setAccessible(true);
+        $prop->setValue($service, $messaging);
+
+        $service->sendToTopic('news', ['foo' => 'bar'], Notification::create('t', 'b'));
+
+        $message = $messaging->sentMessage;
+        $this->assertInstanceOf(CloudMessage::class, $message);
+        $this->assertEquals('topic', $message->targetType);
+        $this->assertEquals('news', $message->target);
+        $this->assertEquals(['foo' => 'bar'], $message->data);
+        $this->assertInstanceOf(Notification::class, $message->notification);
+    }
+
+    public function test_device_token_registration_and_unregistration(): void
+    {
+        $user = User::factory()->create(['password' => bcrypt('secret')]);
+
+        $login = $this->postJson('/api/mobile/v1/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+            'device_name' => 'testing',
+        ]);
+        $token = $login->json('token');
+
+        $this->withToken($token)->postJson('/api/mobile/v1/device/register', ['token' => 'tok'])
+            ->assertOk()->assertJson(['success' => true]);
+        $this->assertEquals('tok', $user->fresh()->fcm_token);
+
+        $this->withToken($token)->postJson('/api/mobile/v1/device/unregister', ['token' => 'tok'])
+            ->assertOk()->assertJson(['success' => true]);
+        $this->assertNull($user->fresh()->fcm_token);
+    }
+
+    public function test_subscribe_to_topic_delegates_to_firebase(): void
+    {
+        $messaging = new MessagingStub();
+        $service = (new \ReflectionClass(PushNotificationService::class))
+            ->newInstanceWithoutConstructor();
+        $prop = new \ReflectionProperty(PushNotificationService::class, 'messaging');
+        $prop->setAccessible(true);
+        $prop->setValue($service, $messaging);
+
+        $service->subscribeToTopic('alerts', ['a', 'b']);
+
+        $this->assertEquals('alerts', $messaging->subscribedTopic);
+        $this->assertEquals(['a', 'b'], $messaging->subscribedTokens);
+    }
+}

--- a/tests/Stubs/FirebaseStubs.php
+++ b/tests/Stubs/FirebaseStubs.php
@@ -9,13 +9,39 @@ class Factory {
 }
 namespace Kreait\Firebase\Messaging;
 class MessagingStub {
-    public function send($message){}
-    public function subscribeToTopic($topic, $token){}
+    public $sentMessage;
+    public $subscribedTopic;
+    public $subscribedTokens;
+
+    public function send($message){
+        $this->sentMessage = $message;
+    }
+
+    public function subscribeToTopic($topic, $token){
+        $this->subscribedTopic = $topic;
+        $this->subscribedTokens = $token;
+    }
 }
 class CloudMessage {
-    public static function withTarget($type, $token){ return new static(); }
-    public function withNotification($notification){ return $this; }
-    public function withData(array $data){ return $this; }
+    public $targetType;
+    public $target;
+    public $notification;
+    public $data = [];
+
+    public static function withTarget($type, $token){
+        $msg = new static();
+        $msg->targetType = $type;
+        $msg->target = $token;
+        return $msg;
+    }
+    public function withNotification($notification){
+        $this->notification = $notification;
+        return $this;
+    }
+    public function withData(array $data){
+        $this->data = $data;
+        return $this;
+    }
 }
 class Notification {
     public static function create($title,$body){ return new static(); }


### PR DESCRIPTION
## Summary
- test push notification service device and topic sending
- test device registration/unregistration endpoints
- update firebase stubs to track sent messages and subscriptions
- register firebase stub in profile unlock tests
- include new feature test in phpunit config

## Testing
- `vendor/bin/phpunit --filter PushNotificationTest --colors=never`
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_b_687224a96b54832ebbeaa750526a74ff