### PR TITLE
Add service worker for offline caching

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,42 @@
+const CACHE_NAME = 'offline-cache-v1';
+const FILES_TO_CACHE = [
+  '/js/app.js',
+  '/css/app.css',
+  '/api/mobile/v1/offline-data'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(FILES_TO_CACHE)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => {
+      return Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      );
+    })
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(cachedResponse => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+      return fetch(event.request).then(response => {
+        if (response && response.status === 200 && response.type === 'basic') {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then(cache => {
+            cache.put(event.request, responseClone);
+          });
+        }
+        return response;
+      });
+    })
+  );
+});

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,6 +18,14 @@
         <!-- Scripts -->
         <script src="{{ asset('js/app.js') }}" defer></script>
 
+        <script>
+            if ('serviceWorker' in navigator) {
+                window.addEventListener('load', function () {
+                    navigator.serviceWorker.register('/sw.js');
+                });
+            }
+        </script>
+
     </head>
     <body class="font-sans antialiased">
 


### PR DESCRIPTION
## Summary
- add service worker to cache JS, CSS and API data
- register the service worker in the main layout

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-reqs` *(fails: Undefined array key `content-hash`)*
- `vendor/bin/phpunit --version` *(fails: autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_6872269e9bf8832eac050b3be91e6bd5