### PR TITLE
Implement geolocation scope for users

### DIFF
--- a/app/Http/Resources/OfflineSyncResource.php
+++ b/app/Http/Resources/OfflineSyncResource.php
@@ -4,15 +4,30 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Cache;
+use App\Models\User;
 
 class OfflineSyncResource extends JsonResource
 {
     public static $wrap = null;
     public function toArray($request)
     {
+        $records = Cache::get("offline-records:{$this->id}", []);
+
+        if (isset($records['nannies']) && is_array($records['nannies'])) {
+            $records['nannies'] = User::query()
+                ->whereIn('id', $records['nannies'])
+                ->nearby([
+                    'lat' => $this->resource->latitude,
+                    'lng' => $this->resource->longitude,
+                ], 20)
+                ->get()
+                ->map(fn ($user) => new UserResource($user))
+                ->all();
+        }
+
         return [
             'profile' => new UserResource($this->resource),
-            'cached_records' => Cache::get("offline-records:{$this->id}", []),
+            'cached_records' => $records,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add a `scopeNearby` method to `User` for distance filtering
- filter cached nanny IDs in `OfflineSyncResource` using the new scope

## Testing
- `composer update --no-interaction --no-progress --ignore-platform-req=ext-sodium`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_6872331a9b60832ead9f00059f34eb2a