### PR TITLE
Add firebase credentials example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,3 +130,7 @@ LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_REDIRECT_URL=
 
+
+# Firebase service account
+FIREBASE_CREDENTIALS=/path/to/firebase_credentials.json
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Kynderway is a Laravel based platform for booking childcare. It provides a REST 
 4. Update `.env` with your local configuration:
    - **MySQL** – `DB_HOST`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`
    - **Stripe** – `STRIPE_SECRET` (your secret key)
-   - **Firebase** – `FIREBASE_CREDENTIALS` (path to the service account json)
+   - **Firebase** – `FIREBASE_CREDENTIALS` should point to your Firebase service account JSON, e.g. `/path/to/firebase_credentials.json`
 5. Run the database migrations:
    ```bash
    php artisan migrate


### PR DESCRIPTION
## Summary
- add Firebase credentials variable to `.env.example`
- document Firebase credentials setup in README

## Testing
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_b_687234db9428832e8cf72e4345809c64