### PR TITLE
Add Cypress and e2e test

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    specPattern: 'cypress/integration/*.spec.js'
+  }
+})

--- a/cypress/integration/booking-flow.spec.js
+++ b/cypress/integration/booking-flow.spec.js
@@ -1,0 +1,9 @@
+describe('Booking Flow', () => {
+  it('allows a user to login and reach dashboard', () => {
+    cy.visit('/login');
+    cy.get('input[name="email"]').type('user@example.com');
+    cy.get('input[name="password"]').type('password');
+    cy.get('form').submit();
+    cy.url().should('include', '/user/client');
+  });
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,1 @@
+// Add custom commands or setup here

--- a/package.json
+++ b/package.json
@@ -1,38 +1,41 @@
 {
-    "private": true,
-    "scripts": {
-        "dev": "npm run development",
-        "development": "mix",
-        "watch": "mix watch",
-        "watch-poll": "mix watch -- --watch-options-poll=1000",
-        "hot": "mix watch --hot",
-        "prod": "npm run production",
-        "production": "mix --production",
-        "vite": "vite",
-        "vite-build": "vite build"
-    },
-    "devDependencies": {
-        "@tailwindcss/forms": "^0.2.1",
-        "alpinejs": "^2.7.3",
-        "autoprefixer": "^10.1.0",
-        "axios": "^0.21",
-        "laravel-mix": "^6.0.6",
-        "lodash": "^4.17.19",
-        "postcss": "^8.2.1",
-        "postcss-import": "^12.0.1",
-        "tailwindcss": "^2.0.2",
-        "vue": "^3.3.4",
-        "vue-loader": "^17.0.1",
-        "@vue/compiler-sfc": "^3.3.4",
-        "vite": "^4.5.0",
-        "@vitejs/plugin-vue": "^4.2.3",
-        "laravel-vite-plugin": "^0.7.2",
-        "vite-plugin-pwa": "^0.16.4"
-    },
-    "dependencies": {
-        "laravel-echo": "^1.15.0",
-        "pusher-js": "^8.0.1",
-        "pinia": "^2.1.6",
-        "vue-router": "^4.2.5"
-    }
+  "private": true,
+  "scripts": {
+    "dev": "npm run development",
+    "development": "mix",
+    "watch": "mix watch",
+    "watch-poll": "mix watch -- --watch-options-poll=1000",
+    "hot": "mix watch --hot",
+    "prod": "npm run production",
+    "production": "mix --production",
+    "vite": "vite",
+    "vite-build": "vite build",
+    "e2e": "cypress run",
+    "e2e:open": "cypress open"
+  },
+  "devDependencies": {
+    "@tailwindcss/forms": "^0.2.1",
+    "@vitejs/plugin-vue": "^4.2.3",
+    "@vue/compiler-sfc": "^3.3.4",
+    "alpinejs": "^2.7.3",
+    "autoprefixer": "^10.1.0",
+    "axios": "^0.21",
+    "cypress": "^14.5.1",
+    "laravel-mix": "^6.0.6",
+    "laravel-vite-plugin": "^0.7.2",
+    "lodash": "^4.17.19",
+    "postcss": "^8.2.1",
+    "postcss-import": "^12.0.1",
+    "tailwindcss": "^2.0.2",
+    "vite": "^4.5.0",
+    "vite-plugin-pwa": "^0.16.4",
+    "vue": "^3.3.4",
+    "vue-loader": "^17.0.1"
+  },
+  "dependencies": {
+    "laravel-echo": "^1.15.0",
+    "pinia": "^2.1.6",
+    "pusher-js": "^8.0.1",
+    "vue-router": "^4.2.5"
+  }
 }


### PR DESCRIPTION
## Summary
- install Cypress and create config
- add booking flow e2e test
- add `e2e` and `e2e:open` npm scripts

## Testing
- `npx cypress run --spec cypress/integration/booking-flow.spec.js` *(fails: could not verify server)*

------
https://chatgpt.com/codex/tasks/task_b_68725a4ecaec832ea2c914462038f019