### PR TITLE
Use resource for profile unlock

### DIFF
--- a/app/Http/Controllers/Api/BrowseController.php
+++ b/app/Http/Controllers/Api/BrowseController.php
@@ -52,7 +52,7 @@ class BrowseController extends Controller
 
         return response()->json([
             'success' => true,
-            'nanny' => $nanny,
+            'nanny' => new \App\Http\Resources\NannyResource($nanny),
             'remaining_credits' => optional($user->credits()->first())->balance ?? 0,
         ]);
     }

--- a/app/Http/Resources/NannyResource.php
+++ b/app/Http/Resources/NannyResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class NannyResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'rating' => round($this->reviewsReceived()->avg('rating') ?? 0, 2),
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -212,7 +212,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
             return $query->select('*')
                 ->selectRaw("{$haversine} as distance_miles", [$lat, $lng, $lat])
-                ->having('distance_miles', '<=', $radius)
+                ->whereRaw("{$haversine} <= ?", [$lat, $lng, $lat, $radius])
                 ->orderBy('distance_miles');
         }
 

--- a/tests/Feature/UnlockNannyApiTest.php
+++ b/tests/Feature/UnlockNannyApiTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserCredit;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class UnlockNannyApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+
+        Schema::create('user_credits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->integer('balance')->default(0);
+            $table->integer('lifetime_purchased')->default(0);
+            $table->integer('lifetime_used')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('credit_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->string('type');
+            $table->integer('amount');
+            $table->integer('balance_after');
+            $table->string('description');
+            $table->string('reference_type')->nullable();
+            $table->unsignedBigInteger('reference_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('reviews', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('reviewer_id');
+            $table->unsignedBigInteger('reviewee_id');
+            $table->unsignedInteger('rating');
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('reviews');
+        Schema::dropIfExists('credit_transactions');
+        Schema::dropIfExists('user_credits');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_unlock_endpoint_returns_sanitized_nanny_data(): void
+    {
+        $parent = User::factory()->create();
+        $nanny = User::factory()->create(['name' => 'Nanny']);
+
+        \DB::table('reviews')->insert([
+            'reviewer_id' => $parent->id,
+            'reviewee_id' => $nanny->id,
+            'rating' => 4,
+        ]);
+
+        UserCredit::create([
+            'user_id' => $parent->id,
+            'balance' => 3,
+            'lifetime_purchased' => 3,
+            'lifetime_used' => 0,
+        ]);
+
+        $response = $this
+            ->withoutMiddleware(\App\Http\Middleware\JwtMiddleware::class)
+            ->actingAs($parent)
+            ->postJson('/api/v1/unlock-nanny/'.$nanny->id);
+
+        $response->assertOk()->assertJsonStructure([
+            'success',
+            'nanny' => ['id', 'name', 'rating'],
+            'remaining_credits',
+        ]);
+
+        $response->assertJson([
+            'success' => true,
+            'nanny' => [
+                'id' => $nanny->id,
+                'name' => 'Nanny',
+                'rating' => 4.0,
+            ],
+            'remaining_credits' => 0,
+        ]);
+    }
+}

--- a/tests/Integration/BookingFlowTest.php
+++ b/tests/Integration/BookingFlowTest.php
@@ -44,6 +44,7 @@ class BookingFlowTest extends TestCase
             $table->decimal('latitude', 10, 6)->nullable();
             $table->decimal('longitude', 10, 6)->nullable();
             $table->decimal('commission_rate', 5, 2)->nullable();
+            $table->softDeletes();
             $table->timestamps();
         });
 


### PR DESCRIPTION
## Summary
- add `NannyResource` to limit fields returned when unlocking a nanny
- respond with `NannyResource` in `BrowseController`
- allow SQLite nearby scope to filter using WHERE
- include deleted_at column in `BookingFlowTest`
- test unlock API serialization

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_68725e7eaca0832eb40cc4a3ff9ab660