### PR TITLE
Add security headers and middleware test

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -15,7 +15,9 @@ class SecurityHeaders
         $response->headers->set('X-Frame-Options', 'DENY');
         $response->headers->set('X-XSS-Protection', '1; mode=block');
         $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        $response->headers->set('Content-Security-Policy', "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'");
         $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Permissions-Policy', 'geolocation=(), microphone=()');
 
         return $response;
     }

--- a/tests/Unit/SecurityHeadersTest.php
+++ b/tests/Unit/SecurityHeadersTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Middleware\SecurityHeaders;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    public function test_security_headers_are_added()
+    {
+        $middleware = new SecurityHeaders();
+        $request = Request::create('/', 'GET');
+
+        $response = $middleware->handle($request, function () {
+            return response('OK');
+        });
+
+        $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
+        $this->assertEquals('DENY', $response->headers->get('X-Frame-Options'));
+        $this->assertEquals('1; mode=block', $response->headers->get('X-XSS-Protection'));
+        $this->assertEquals('max-age=31536000; includeSubDomains', $response->headers->get('Strict-Transport-Security'));
+        $this->assertEquals("default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'", $response->headers->get('Content-Security-Policy'));
+        $this->assertEquals('strict-origin-when-cross-origin', $response->headers->get('Referrer-Policy'));
+        $this->assertEquals('geolocation=(), microphone=()', $response->headers->get('Permissions-Policy'));
+    }
+}


### PR DESCRIPTION
## Summary
- extend security headers middleware to set Content-Security-Policy and Permissions-Policy
- test security headers middleware

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_6872763462e0832e9c9a670cbed02b2d