### PR TITLE
Implement Checkr service integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,6 +132,8 @@ LINKEDIN_REDIRECT_URL=
 
 CURRENCY_RATES_API_KEY=
 
+CHECKR_SECRET=
+
 # Firebase service account
 FIREBASE_CREDENTIALS=/path/to/firebase_credentials.json
 

--- a/app/Services/CheckrService.php
+++ b/app/Services/CheckrService.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+
+class CheckrService
+{
+    protected string $baseUrl = 'https://api.checkr.com/v1/';
+    protected string $secret;
+
+    public function __construct()
+    {
+        $this->secret = config('services.checkr.secret');
+    }
+
+    protected function client()
+    {
+        return Http::withBasicAuth($this->secret, '');
+    }
+
+    /**
+     * Create a candidate on Checkr
+     */
+    public function createCandidate(array $data)
+    {
+        if (isset($data['ssn'])) {
+            // ssn value is expected to be encrypted when provided
+            $data['ssn'] = Crypt::decryptString($data['ssn']);
+        }
+
+        $response = $this->client()->post($this->baseUrl . 'candidates', $data);
+        $response->throw();
+
+        return (object) $response->json();
+    }
+
+    /**
+     * Create a report for a candidate
+     */
+    public function createReport(string $candidateId, array $data)
+    {
+        $payload = array_merge($data, ['candidate_id' => $candidateId]);
+        $response = $this->client()->post($this->baseUrl . 'reports', $payload);
+        $response->throw();
+
+        return (object) $response->json();
+    }
+}

--- a/app/Services/KYCService.php
+++ b/app/Services/KYCService.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Models\VerificationDocument;
 use Aws\Rekognition\RekognitionClient;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Crypt;
 
 class KYCService
 {
@@ -71,7 +72,7 @@ class KYCService
             'email' => $user->email,
             'phone' => $user->phone,
             'dob' => $user->date_of_birth,
-            'ssn' => $user->ssn, // Encrypted
+            'ssn' => Crypt::encryptString($user->ssn),
             'zipcode' => $user->zipcode,
         ]);
 

--- a/config/services.php
+++ b/config/services.php
@@ -66,4 +66,8 @@ return [
         'client_secret' => env('LINKEDIN_CLIENT_SECRET'),
         'redirect' => env('LINKEDIN_REDIRECT_URL'),
     ],
+
+    'checkr' => [
+        'secret' => env('CHECKR_SECRET'),
+    ],
 ];


### PR DESCRIPTION
## Summary
- add `CHECKR_SECRET` to env example
- configure Checkr secret in services config
- create `CheckrService` with `createCandidate` and `createReport`
- encrypt SSN before calling Checkr

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `composer lint` *(fails: Finder logic exception)*
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_68732f8184a0832e8bbe473318fa145e