### PR TITLE
Restrict php-info route to non-production

### DIFF
--- a/app/Http/Controllers/GuestController.php
+++ b/app/Http/Controllers/GuestController.php
@@ -40,11 +40,6 @@ class GuestController extends Controller
         $this->slug = $slug;
     }
 
-    public function getPhpInfo()
-    {
-        echo phpinfo();
-        die();
-    }
 
     public function viewPDF(Request $request)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1135,10 +1135,6 @@ parameters:
 			count: 1
 			path: app/Http/Controllers/GuestController.php
 
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\GuestController\\:\\:getPhpInfo\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/GuestController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\GuestController\\:\\:getProfile\\(\\) has no return type specified\\.$#"

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,7 +104,11 @@ Route::post('/user/exit-intro', function () {
     }
 });
 
-Route::get('/php-get', [GuestController::class, 'getPhpInfo']);   //optimized
+if (!app()->environment('production')) {
+    Route::get('/php-get', function () {
+        phpinfo();
+    });
+}
 
 Route::get('/mail/admin-delete-user-account', [EmailsController::class, 'adminAccountDelete']);   //optimized
 Route::get('/mail/user-account-delete', [EmailsController::class, 'userAccountDelete']);   //optimized


### PR DESCRIPTION
## Summary
- drop unused `getPhpInfo()` helper
- gate `/php-get` route behind environment check
- clean up phpstan baseline

## Testing
- `vendor/bin/phpunit -c phpunit.xml --testsuite Unit --testsuite Feature --testsuite Integration`

------
https://chatgpt.com/codex/tasks/task_b_68733173d07c832ea463cf24eb9b768a