### PR TITLE
Add social accounts management

### DIFF
--- a/app/Http/Controllers/Auth/SocialAuthController.php
+++ b/app/Http/Controllers/Auth/SocialAuthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Models\SocialAccount;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Exception;
@@ -26,14 +27,29 @@ class SocialAuthController extends Controller
         try {
             $socialUser = Socialite::driver($provider)->user();
 
-            $user = User::updateOrCreate([
-                'email' => $socialUser->getEmail(),
-            ], [
-                'name' => $socialUser->getName(),
-                'provider' => $provider,
-                'provider_id' => $socialUser->getId(),
-                'avatar' => $socialUser->getAvatar(),
-            ]);
+            $user = User::updateOrCreate(
+                [
+                    'email' => $socialUser->getEmail(),
+                ],
+                [
+                    'name' => $socialUser->getName(),
+                    'provider' => $provider,
+                    'provider_id' => $socialUser->getId(),
+                    'avatar' => $socialUser->getAvatar(),
+                ]
+            );
+
+            $user->socialAccounts()->updateOrCreate(
+                [
+                    'provider' => $provider,
+                    'provider_id' => $socialUser->getId(),
+                ],
+                [
+                    'token' => $socialUser->token,
+                    'refresh_token' => $socialUser->refreshToken,
+                    'expires_at' => $socialUser->expiresIn ? now()->addSeconds($socialUser->expiresIn) : null,
+                ]
+            );
 
             Auth::login($user);
 

--- a/app/Models/SocialAccount.php
+++ b/app/Models/SocialAccount.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SocialAccount extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'provider',
+        'provider_id',
+        'token',
+        'refresh_token',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -184,6 +184,11 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(PaymentMethod::class);
     }
 
+    public function socialAccounts()
+    {
+        return $this->hasMany(SocialAccount::class);
+    }
+
     public function unlockedProfiles()
     {
         return $this->hasMany(UnlockedProfile::class, 'parent_id');

--- a/database/factories/SocialAccountFactory.php
+++ b/database/factories/SocialAccountFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SocialAccount;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class SocialAccountFactory extends Factory
+{
+    protected $model = SocialAccount::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'provider' => $this->faker->randomElement(['google', 'facebook']),
+            'provider_id' => (string) Str::uuid(),
+            'token' => $this->faker->sha256,
+            'refresh_token' => $this->faker->sha256,
+            'expires_at' => now()->addDay(),
+        ];
+    }
+}

--- a/database/migrations/2024_01_04_create_social_accounts_table.php
+++ b/database/migrations/2024_01_04_create_social_accounts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('social_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('provider', 20);
+            $table->string('provider_id');
+            $table->text('token')->nullable();
+            $table->text('refresh_token')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['provider', 'provider_id']);
+            $table->index(['user_id', 'provider']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('social_accounts');
+    }
+};


### PR DESCRIPTION
## Summary
- migrate `social_accounts` table
- add SocialAccount model and factory
- link SocialAccount with users
- store OAuth tokens during social login

## Testing
- `composer lint` *(fails: Finder exception)*
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_6873332a9090832e877ddf6f3a2d045b