### PR TITLE
Implement Checkr background checks

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -77,7 +77,12 @@ class User extends Authenticatable implements MustVerifyEmail
         'otp',
         'otp_send_at',
         'is_new',
-        'credits'
+        'credits',
+        'ssn',
+        'checkr_candidate_id',
+        'background_check_report_id',
+        'background_check_status',
+        'background_check_initiated_at'
     ];
 
     /**
@@ -88,6 +93,7 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $hidden = [
         'password',
         'remember_token',
+        'ssn',
     ];
 
     /**
@@ -97,6 +103,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'background_check_initiated_at' => 'datetime',
     ];
 
     public function sendEmailVerificationNotification()

--- a/app/Services/KYCService.php
+++ b/app/Services/KYCService.php
@@ -61,24 +61,32 @@ class KYCService
      */
     public function performBackgroundCheck($user)
     {
-        // Integration with background check services
-        // Examples: Checkr, Sterling, GoodHire
-
         $backgroundCheckService = new \App\Services\CheckrService();
 
-        $candidate = $backgroundCheckService->createCandidate([
-            'first_name' => $user->first_name,
-            'last_name' => $user->last_name,
-            'email' => $user->email,
-            'phone' => $user->phone,
-            'dob' => $user->date_of_birth,
-            'ssn' => Crypt::encryptString($user->ssn),
-            'zipcode' => $user->zipcode,
-        ]);
+        if (!$user->checkr_candidate_id) {
+            $candidate = $backgroundCheckService->createCandidate([
+                'first_name' => $user->name,
+                'last_name' => $user->last_name,
+                'email' => $user->email,
+                'phone' => $user->phone,
+                'dob' => $user->birth_date,
+                'ssn' => $user->ssn,
+                'zipcode' => $user->postal_code,
+            ]);
+
+            $user->checkr_candidate_id = $candidate->id;
+        } else {
+            $candidate = (object) ['id' => $user->checkr_candidate_id];
+        }
 
         $report = $backgroundCheckService->createReport($candidate->id, [
-            'package' => 'childcare_pro', // Criminal, sex offender registry, etc.
+            'package' => 'childcare_pro',
         ]);
+
+        $user->background_check_report_id = $report->id;
+        $user->background_check_status = $report->status ?? 'pending';
+        $user->background_check_initiated_at = now();
+        $user->save();
 
         return $report;
     }

--- a/database/migrations/2025_08_01_000007_add_background_check_fields_to_users_table.php
+++ b/database/migrations/2025_08_01_000007_add_background_check_fields_to_users_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'ssn')) {
+                $table->string('ssn')->nullable()->after('remember_token');
+            }
+            if (!Schema::hasColumn('users', 'checkr_candidate_id')) {
+                $table->string('checkr_candidate_id')->nullable()->after('ssn');
+            }
+            if (!Schema::hasColumn('users', 'background_check_report_id')) {
+                $table->string('background_check_report_id')->nullable()->after('checkr_candidate_id');
+            }
+            if (!Schema::hasColumn('users', 'background_check_status')) {
+                $table->string('background_check_status')->nullable()->after('background_check_report_id');
+            }
+            if (!Schema::hasColumn('users', 'background_check_initiated_at')) {
+                $table->timestamp('background_check_initiated_at')->nullable()->after('background_check_status');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'background_check_initiated_at')) {
+                $table->dropColumn('background_check_initiated_at');
+            }
+            if (Schema::hasColumn('users', 'background_check_status')) {
+                $table->dropColumn('background_check_status');
+            }
+            if (Schema::hasColumn('users', 'background_check_report_id')) {
+                $table->dropColumn('background_check_report_id');
+            }
+            if (Schema::hasColumn('users', 'checkr_candidate_id')) {
+                $table->dropColumn('checkr_candidate_id');
+            }
+            if (Schema::hasColumn('users', 'ssn')) {
+                $table->dropColumn('ssn');
+            }
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,7 @@
             <file>./tests/Feature/PushNotificationTest.php</file>
             <file>./tests/Feature/PaymentEndpointsTest.php</file>
             <file>./tests/Feature/PayoutEndpointsTest.php</file>
+            <file>./tests/Feature/BackgroundCheckTest.php</file>
         </testsuite>
         <testsuite name="Integration">
             <directory suffix="Test.php">./tests/Integration</directory>

--- a/tests/Feature/BackgroundCheckTest.php
+++ b/tests/Feature/BackgroundCheckTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+use App\Services\KYCService;
+
+class StubKYCService extends KYCService
+{
+    public function __construct()
+    {
+        // Skip parent constructor to avoid AWS SDK dependency
+    }
+}
+
+class BackgroundCheckTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->string('remember_token')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('postal_code')->nullable();
+            $table->date('birth_date')->nullable();
+            $table->string('ssn')->nullable();
+            $table->string('checkr_candidate_id')->nullable();
+            $table->string('background_check_report_id')->nullable();
+            $table->string('background_check_status')->nullable();
+            $table->timestamp('background_check_initiated_at')->nullable();
+            $table->timestamps();
+        });
+
+        $this->app->instance(KYCService::class, new StubKYCService());
+
+        config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+        config(['services.checkr.secret' => 'test_secret']);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_background_check_can_be_initiated()
+    {
+        Http::fake([
+            'https://api.checkr.com/v1/candidates' => Http::response(['id' => 'cand_1'], 200),
+            'https://api.checkr.com/v1/reports' => Http::response(['id' => 'rpt_1', 'status' => 'pending'], 200),
+        ]);
+
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->postJson('/api/v1/kyc/background-check', [
+            'consent' => '1',
+            'ssn' => '123456789',
+        ]);
+
+        $response->assertOk()->assertJson([
+            'report_id' => 'rpt_1',
+            'status' => 'pending',
+        ]);
+
+        $user->refresh();
+        $this->assertEquals('cand_1', $user->checkr_candidate_id);
+        $this->assertEquals('rpt_1', $user->background_check_report_id);
+        $this->assertEquals('pending', $user->background_check_status);
+        $this->assertEquals('123456789', Crypt::decryptString($user->ssn));
+    }
+
+    public function test_repeated_background_check_attempt_is_rejected()
+    {
+        Http::fake([
+            'https://api.checkr.com/v1/candidates' => Http::response(['id' => 'cand_1'], 200),
+            'https://api.checkr.com/v1/reports' => Http::response(['id' => 'rpt_1', 'status' => 'pending'], 200),
+        ]);
+
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $this->postJson('/api/v1/kyc/background-check', [
+            'consent' => '1',
+            'ssn' => '123456789',
+        ])->assertOk();
+
+        $response = $this->postJson('/api/v1/kyc/background-check', [
+            'consent' => '1',
+            'ssn' => '123456789',
+        ]);
+
+        $response->assertStatus(409);
+    }
+}


### PR DESCRIPTION
## Summary
- add user columns for Checkr background checks
- support candidate and report creation via CheckrService
- store background check info from KYCController
- update KYCService to persist candidate/report IDs
- cover background check flow in feature tests

## Testing
- `./vendor/bin/phpunit --filter BackgroundCheckTest`
- `./vendor/bin/phpunit --testsuite Feature`

------
https://chatgpt.com/codex/tasks/task_b_68733337b338832ea412c2a12613e547