### PR TITLE
Add booking events and notifications

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,12 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->append([
+        __DIR__.'/app/Events/BookingCreated.php',
+        __DIR__.'/app/Listeners/SendBookingNotification.php',
+        __DIR__.'/app/Providers/EventServiceProvider.php',
+        __DIR__.'/app/Services/BookingService.php',
+    ]);
+
+return (new PhpCsFixer\Config())
+    ->setRules(['@PSR12' => true])
+    ->setFinder($finder);

--- a/app/Events/BookingCreated.php
+++ b/app/Events/BookingCreated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Booking;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class BookingCreated
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public Booking $booking)
+    {
+    }
+}

--- a/app/Listeners/SendBookingNotification.php
+++ b/app/Listeners/SendBookingNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\BookingCreated;
+use App\Services\PushNotificationService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Kreait\Firebase\Messaging\Notification;
+
+class SendBookingNotification implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public function handle(BookingCreated $event): void
+    {
+        $booking = $event->booking;
+        $provider = $booking->nanny;
+
+        if (!$provider || !$provider->fcm_token) {
+            return;
+        }
+
+        app(PushNotificationService::class)->sendToDevice(
+            $provider->fcm_token,
+            [
+                'booking_id' => $booking->id,
+                'type'       => 'new_booking',
+            ],
+            Notification::create(
+                'New Booking Request',
+                "{$booking->parent->name} has requested a booking"
+            )
+        );
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-
 use App\Events\ProfileDelete;
 use App\Events\ProfileActivate;
 use App\Events\JobDelete;
@@ -20,7 +19,7 @@ use App\Events\UserDeleteEmailAdminEvent;
 use App\Events\CreditsPurchased;
 use App\Events\CreditsUsed;
 use App\Events\PaymentProcessed;
-
+use App\Events\BookingCreated;
 use App\Listeners\SendJobDeleteMail;
 use App\Listeners\SendProfileActivateMail;
 use App\Listeners\SendProfileDeleteMail;
@@ -34,6 +33,7 @@ use App\Listeners\SendUserAccountDeleteMail;
 use App\Listeners\SendUserDeleteAdminMail;
 use App\Listeners\SendCreditPurchaseNotification;
 use App\Listeners\UpdateUserCreditsBalance;
+use App\Listeners\SendBookingNotification;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -85,6 +85,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         CreditsUsed::class => [
             UpdateUserCreditsBalance::class,
+        ],
+        BookingCreated::class => [
+            SendBookingNotification::class,
         ],
         PaymentProcessed::class => [],
 

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -4,9 +4,9 @@ namespace App\Services;
 
 use App\Models\Booking;
 use Illuminate\Support\Facades\DB;
-
 use App\Services\PushNotificationService;
 use Kreait\Firebase\Messaging\Notification;
+use App\Events\BookingCreated;
 
 class BookingService
 {
@@ -22,17 +22,7 @@ class BookingService
             $booking = Booking::create($data);
             $this->paymentService->createEscrowPayment($booking);
 
-            $this->notificationService->sendToDevice(
-                $booking->nanny->fcm_token,
-                [
-                    'booking_id' => $booking->id,
-                    'type' => 'new_booking',
-                ],
-                Notification::create(
-                    'New Booking Request',
-                    "{$booking->parent->name} has requested a booking"
-                )
-            );
+            event(new BookingCreated($booking));
             return $booking->fresh();
         });
     }


### PR DESCRIPTION
## Summary
- dispatch `BookingCreated` event and listener to send push notifications
- queue send booking notification and use provider `fcm_token`
- register booking event in `EventServiceProvider`
- add CS fixer config for linting

## Testing
- `composer lint`
- `./vendor/bin/phpunit` *(fails: Tests: 40, Assertions: 88, Errors: 5)*

------
https://chatgpt.com/codex/tasks/task_b_6873334ddd6c832e8b1f3fae4b2f7603