### PR TITLE
Add /health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /var/www/storage /var/www/bootstrap/cache \
  && chmod +x /entrypoint.sh \
  && chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache
 
-HEALTHCHECK --interval=30s --timeout=3s CMD php -r "echo 'OK';"
+HEALTHCHECK --interval=30s --timeout=5s CMD wget -qO- http://localhost/health > /dev/null || exit 1
 EXPOSE 9000
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ docker-compose up --build
 
 Prometheus and Grafana containers are also started for metrics at `http://localhost:9090` and `http://localhost:3000`.
 
+The application exposes two endpoints for monitoring:
+
+* `GET /metrics` – Prometheus format metrics
+* `GET /health` – returns `{"status":"ok","database":"up"}` when the app and database are reachable
+
 ## Tests and linting
 
 - Execute the test suite:

--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+
+class HealthController extends Controller
+{
+    public function __invoke()
+    {
+        try {
+            DB::connection()->select('SELECT 1');
+            $db = true;
+        } catch (\Throwable $e) {
+            $db = false;
+        }
+
+        return response()->json([
+            'status' => 'ok',
+            'database' => $db ? 'up' : 'down',
+        ]);
+    }
+}

--- a/routes/metrics.php
+++ b/routes/metrics.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\MetricsController;
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/metrics', MetricsController::class);
+Route::get('/health', HealthController::class);

--- a/tests/Feature/HealthEndpointTest.php
+++ b/tests/Feature/HealthEndpointTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class HealthEndpointTest extends TestCase
+{
+    public function test_health_endpoint_returns_ok()
+    {
+        $response = $this->get('/health');
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'status' => 'ok',
+                 ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `HealthController` with basic DB check
- expose `/health` route alongside `/metrics`
- update Dockerfile to use the new endpoint for container health
- document monitoring endpoints in README
- add feature test covering `/health`

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `php artisan test` *(fails: Class "Database\Factories\UserFactory" not found)*

------
https://chatgpt.com/codex/tasks/task_b_6875a3e94050832e8c72af652f8ffe4b